### PR TITLE
warning fixes for newer cpp compilers

### DIFF
--- a/example/example5.cpp
+++ b/example/example5.cpp
@@ -37,7 +37,7 @@ float sphere_rotate[16] = { 1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1 };
 float torus_rotate[16] = { 1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1 };
 float view_rotate[16] = { 1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1 };
 float obj_pos[] = { 0.0, 0.0, 0.0 };
-char *string_list[] = { "Hello World!", "Foo", "Testing...", "Bounding box: on" };
+const char *string_list[] = { "Hello World!", "Foo", "Testing...", "Bounding box: on" };
 int   curr_string = 0;
 
 /** Pointers to the windows and some of the controls we'll create **/

--- a/glui_edittext.cpp
+++ b/glui_edittext.cpp
@@ -933,7 +933,7 @@ int    GLUI_EditText::special_handler( int key,int modifiers )
 int    GLUI_EditText::find_word_break( int start, int direction )
 {
   int    i, j;
-  char   *breaks = " :-.,";
+  const char   *breaks = " :-.,";
   int     num_break_chars = (int)strlen(breaks), text_len = (int)text.length();
   int     new_pt;
 

--- a/glui_filebrowser.cpp
+++ b/glui_filebrowser.cpp
@@ -81,7 +81,7 @@ void GLUI_FileBrowser::dir_list_callback(GLUI_Control *glui_object) {
     if (selected[0] == '/' || selected[0] == '\\') {
       if (me->allow_change_dir) {
 #ifdef __GNUC__
-        chdir(selected+1);
+        AssertResult(0,chdir(selected+1));
 #endif
 #ifdef _WIN32
         SetCurrentDirectory(selected+1);

--- a/glui_internal.h
+++ b/glui_internal.h
@@ -67,7 +67,7 @@
 /*! evaluates the 'expr' in the second parameter, and does an assert()
   on this expr's result being the same as the (int) value passed in
   'desired' */
-#define AssertResult(desired,expr) { int rc = expr; assert(rc == rc); }
+#define AssertResult(desired,expr) { int rc = (expr); assert(rc == (desired)); }
 
 /************************* floating-point random ********************/
 #ifndef randf

--- a/glui_internal.h
+++ b/glui_internal.h
@@ -20,6 +20,7 @@
 
 #include <cstdio>
 #include <cmath>
+#include <assert.h>
 
 #ifndef AND
 #define AND &&
@@ -48,7 +49,6 @@
 #define TEST_AND( a, b ) ((a&b)==b)
 #endif
 
-
 #ifndef M_PI
 #define M_PI 3.141592654
 #endif
@@ -63,6 +63,11 @@
 #ifndef error_return
 #define error_return( c ); {fprintf(stderr,c);return;}
 #endif
+
+/*! evaluates the 'expr' in the second parameter, and does an assert()
+  on this expr's result being the same as the (int) value passed in
+  'desired' */
+#define AssertResult(desired,expr) { int rc = expr; assert(rc == rc); }
 
 /************************* floating-point random ********************/
 #ifndef randf

--- a/glui_textbox.cpp
+++ b/glui_textbox.cpp
@@ -1067,10 +1067,10 @@ void    GLUI_TextBox::set_text( const char *new_text )
 
 /*************************************** GLUI_TextBox::dump() **************/
 
-void   GLUI_TextBox::dump( FILE *out, char *name )
+void   GLUI_TextBox::dump( FILE *out, const char *name )
 {
   fprintf( out,
-       "%s (edittext@%p):   line:%d ins_pt:%d  subs:%d/%d  sel:%d/%d   len:%d\n",
+       "%s (edittext@%p):   line:%d ins_pt:%d  subs:%d/%d  sel:%d/%d   len:%ld\n",
        name, this, curr_line,
        insertion_pt, substring_start, substring_end, sel_start, sel_end,
        text.length());

--- a/include/GL/glui.h
+++ b/include/GL/glui.h
@@ -2041,7 +2041,7 @@ public:
     void set_text( const char *text );
     const char *get_text( void )         { return text.c_str(); }
 
-    void dump( FILE *out, char *text );
+    void dump( FILE *out, const char *text );
     void set_tab_w(int w) { tab_width = w; }
     void set_start_line(int l) { start_line = l; }
     static void scrollbar_callback(GLUI_Control*);

--- a/tools/ppm.cpp
+++ b/tools/ppm.cpp
@@ -12,6 +12,7 @@
 
 #define PPM_VERBOSE 0
 
+#define AssertResult(desired,expr) { int rc = expr; assert(rc == rc); }
 
 void VFlip(unsigned char * Pix, int width, int height, int chan)
 {
@@ -46,13 +47,13 @@ void LoadPPM(const char *FileName, unsigned char* &Color, int &Width, int &Heigh
   int c,s;
   do{ do { s=fgetc(fp); } while (s!='\n'); } while ((c=fgetc(fp))=='#');
   ungetc(c,fp);
-  fscanf(fp, "%d %d\n255\n", &Width, &Height);
+  AssertResult(2,fscanf(fp, "%d %d\n255\n", &Width, &Height));
 #if PPM_VERBOSE
   printf("Reading %dx%d Texture [%s]. . .\n", Width, Height, FileName);
 #endif
   int NumComponents = Width*Height*3;
   if (Color==NULL) Color = new unsigned char[NumComponents];
-  fread(Color,NumComponents,1,fp);
+  AssertResult(1,fread(Color,NumComponents,1,fp));
   fclose(fp);
 }
 

--- a/tools/ppm.cpp
+++ b/tools/ppm.cpp
@@ -12,7 +12,7 @@
 
 #define PPM_VERBOSE 0
 
-#define AssertResult(desired,expr) { int rc = expr; assert(rc == rc); }
+#include "../glui_internal.h"
 
 void VFlip(unsigned char * Pix, int width, int height, int chan)
 {


### PR DESCRIPTION
Existing release contained several instances of code that produced warnings on gcc - missing 'const' in const char *-type strings, non-checked return values of fread, fscan, etc. This diff fixes those for
c++ (Ubuntu 5.4.0-6ubuntu1~16.04.4) 5.4.0 20160609; for which it now compiles in cmake/release without any warnings. 