### PR TITLE
Add .gitignore for filtering out build outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+
+*.o
+/bin/
+/lib/
+
+# Conventional cmake build directory
+/build/


### PR DESCRIPTION
I'm evaluating Axosoft GitKraken as a git UI.  There are various .o files and so on that we'd rather git didn't pay attention to. 