### PR TITLE
Cmake install rules

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,41 @@
+# GLUI
+
+##  Dependencies
+
+GLUI depends on OpenGL and GLUT. You can use a CMake with a minimum version is 2.8.12
+to build the library.
+
+## Building Instructions
+
+In order to build the library you can do
+
+```bash
+mkdir build
+cd build
+cmake .. -DCMAKE_INSTALL_PREFIX:PATH=path/to/install
+make install -j4
+```
+
+In order to use the library as a third party in a cmake project you can add this to your `CMakeLists.txt`:
+
+```cmake
+# Find the package from the gluiConfig.cmake
+# in <prefix>/lib/cmake/glui/. Under the namespace glui::
+# it exposes the target glui that allows you to compile
+# and link with the library
+find_package(glui CONFIG REQUIRED)
+...
+# suppose you want to try it out in a executable
+add_executable(gluitest yourfile.cpp)
+# add link to the library, use glui::glui_static if you want to link with the static version
+target_link_libraries(gluitest PUBLIC glui::glui)
+```
+Check the `CMakeLists.txt` in the examples folder for an example.
+
+When you install glui, a file `gluiConfig.cmake` is installed in `path/to/install/lib/cmake/glui/`
+that allows you to import the library in your CMake project by passing the
+location of `gluiConfig.cmake` from the cmake command line:
+
+```bash
+cmake .. -Dglui_DIR=path/to/install/lib/cmake/glui/
+```

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,10 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 project(glui)
+set(PROJECT_VERSION 2.37)
 
 find_package(GLUT REQUIRED)
 find_package(OpenGL REQUIRED)
-
-include_directories(${GLUT_INCLUDE_DIR}/include)
-include_directories(${CMAKE_SOURCE_DIR}/include)
 
 SET(GLUI_SRCS
  algebra3.cpp
@@ -44,15 +42,37 @@ SET(GLUI_SRCS
  viewmodel.cpp
 )
 add_library(glui_obj OBJECT ${GLUI_SRCS})
+target_include_directories(glui_obj
+      PUBLIC
+      "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>"
+      ${OPENGL_INCLUDE_DIR}
+      ${GLUT_INCLUDE_DIR})
 # we need to enable -fPIC this so that the same object code can be used to
 # create static *and* shared libraries without double compilation
-set_property(TARGET glui_obj PROPERTY POSITION_INDEPENDENT_CODE 1)
+set_target_properties( glui_obj PROPERTIES POSITION_INDEPENDENT_CODE 1)
 
 add_library(glui SHARED $<TARGET_OBJECTS:glui_obj>)
-target_link_libraries(glui ${GLUT_LIBRARIES} ${OPENGL_LIBRARIES})
+target_include_directories(glui
+      PUBLIC
+      "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>"
+      "$<INSTALL_INTERFACE:include>"
+      ${OPENGL_INCLUDE_DIR}
+      ${GLUT_INCLUDE_DIR})
+target_link_libraries(glui PUBLIC ${GLUT_LIBRARIES} ${OPENGL_LIBRARIES})
+set_target_properties(glui PROPERTIES
+  DEBUG_POSTFIX "d"
+  VERSION ${PROJECT_VERSION}
+  SOVERSION ${PROJECT_VERSION})
 
 add_library(glui_static STATIC $<TARGET_OBJECTS:glui_obj>)
-target_link_libraries(glui_static ${GLUT_LIBRARIES})
+target_include_directories(glui_static
+      PUBLIC
+      "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>"
+      "$<INSTALL_INTERFACE:include>"
+      ${OPENGL_INCLUDE_DIR}
+      ${GLUT_INCLUDE_DIR})
+target_link_libraries(glui_static PUBLIC ${GLUT_LIBRARIES} ${OPENGL_LIBRARIES})
+set_target_properties(glui_static PROPERTIES DEBUG_POSTFIX "d")
 
 add_executable(ppm2array tools/ppm.cpp tools/ppm2array.cpp)
 target_link_libraries(ppm2array)
@@ -69,3 +89,65 @@ add_executable(example5 example/example5.cpp)
 target_link_libraries(example5 glui_static ${GLUT_LIBRARIES} ${OPENGL_LIBRARIES})
 add_executable(example6 example/example6.cpp)
 target_link_libraries(example6 glui_static ${GLUT_LIBRARIES} ${OPENGL_LIBRARIES})
+
+
+
+####
+# Installation
+
+set(config_install_dir "lib/cmake/${PROJECT_NAME}")
+set(include_install_dir "include")
+
+set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+# Configuration
+set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
+set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+set(targets_export_name "${PROJECT_NAME}Targets")
+set(namespace "${PROJECT_NAME}::")
+
+# Include module with fuction 'write_basic_package_version_file'
+include(CMakePackageConfigHelpers)
+
+# Configure '<PROJECT-NAME>ConfigVersion.cmake'
+write_basic_package_version_file(
+    "${version_config}" VERSION ${PROJECT_VERSION} COMPATIBILITY SameMajorVersion
+)
+
+# Configure '<PROJECT-NAME>Config.cmake'
+configure_package_config_file(
+    "cmake/Config.cmake.in"
+    "${project_config}"
+    INSTALL_DESTINATION "${config_install_dir}"
+)
+
+# Targets:
+install(
+    TARGETS glui_static glui
+    EXPORT "${targets_export_name}"
+    LIBRARY DESTINATION "lib"
+    ARCHIVE DESTINATION "lib"
+    RUNTIME DESTINATION "bin"
+    INCLUDES DESTINATION "${include_install_dir}"
+)
+
+# Headers:
+install(
+    DIRECTORY "${CMAKE_SOURCE_DIR}/include/"
+    DESTINATION "${include_install_dir}"
+    FILES_MATCHING PATTERN "*.h"
+)
+
+
+# Config
+install(
+    FILES "${project_config}" "${version_config}"
+    DESTINATION "${config_install_dir}"
+)
+
+# Config
+install(
+    EXPORT "${targets_export_name}"
+    NAMESPACE "${namespace}"
+    DESTINATION "${config_install_dir}"
+)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 2.8.12)
+
+project(GluiExamples)
+
+find_package(GLUT REQUIRED)
+find_package(OpenGL REQUIRED)
+
+find_package(glui REQUIRED)
+
+add_executable(example1 example1.cpp)
+target_link_libraries(example1 glui::glui_static ${GLUT_LIBRARIES} ${OPENGL_LIBRARIES})
+add_executable(example2 example2.cpp)
+target_link_libraries(example2 glui::glui_static ${GLUT_LIBRARIES} ${OPENGL_LIBRARIES})
+add_executable(example3 example3.cpp)
+target_link_libraries(example3 glui::glui_static ${GLUT_LIBRARIES} ${OPENGL_LIBRARIES})
+add_executable(example4 example4.cpp)
+target_link_libraries(example4 glui::glui_static ${GLUT_LIBRARIES} ${OPENGL_LIBRARIES})
+add_executable(example5 example5.cpp)
+target_link_libraries(example5 glui::glui_static ${GLUT_LIBRARIES} ${OPENGL_LIBRARIES})
+add_executable(example6 example6.cpp)
+target_link_libraries(example6 glui::glui_static ${GLUT_LIBRARIES} ${OPENGL_LIBRARIES})


### PR DESCRIPTION
Hi @josch 

I  added the cmake install rules to make it easier to use the library as a third party. Now `make install` install all the built libs, the headers and the examples in `CMAKE_INSTALL_PREFIX` (default /usr/local). More importantly, it generates the `gluiConfig.cmake` (in lib/cmake/glui/) that can be used to import the library in another cmake project. I added a BUILD.md that explains it, it is basically enough to write

```cmake
# Find the package from the gluiConfig.cmake
# in <prefix>/lib/cmake/glui/. Under the namespace glui::
# it exposes the target glui that allows you to compile
# and link with the library
find_package(glui CONFIG REQUIRED)
...
# suppose you want to try it out in a executable
add_executable(gluitest yourfile.cpp)
# add link to the library, use glui::glui_static if you want to link with the static version
target_link_libraries(gluitest PUBLIC glui::glui)
```
and then  passing the location of `gluiConfig.cmake` from the cmake command line:

```bash
cmake .. -Dglui_DIR=path/to/install/lib/cmake/glui/
```

Incidentally, I needed to make the minimum required version to 2.8.12 in order to use `PUBLIC` and `PRIVATE` in `target_link_libraries()`, which is very important to propagate correctly the secondary dependencies.

I hope it may help

S.