### PR TITLE
Code tidy-up: void parameters not needed in C++

### DIFF
--- a/algebra3.cpp
+++ b/algebra3.cpp
@@ -5,8 +5,8 @@
   GLUI User Interface Toolkit
   Copyright (c) 1998-2007 Paul Rademacher
 
-  WWW:    http://sourceforge.net/projects/glui/
-  Forums: http://sourceforge.net/forum/?group_id=92496
+  WWW:    https://github.com/libglui/glui
+  Issues: https://github.com/libglui/glui/issues
 
   This software is provided 'as-is', without any express or implied
   warranty. In no event will the authors be held liable for any damages
@@ -485,7 +485,7 @@ vec3 &vec3::normalize() // it is up to caller to avoid divide-by-zero
     return *this;
 }
 
-vec3 &vec3::homogenize(void) // it is up to caller to avoid divide-by-zero
+vec3 &vec3::homogenize() // it is up to caller to avoid divide-by-zero
 {
     n[VX] /= n[VZ];
     n[VY] /= n[VZ];

--- a/algebra3.cpp
+++ b/algebra3.cpp
@@ -5,8 +5,8 @@
   GLUI User Interface Toolkit
   Copyright (c) 1998-2007 Paul Rademacher
 
-  WWW:    https://github.com/libglui/glui
-  Issues: https://github.com/libglui/glui/issues
+  WWW:    http://sourceforge.net/projects/glui/
+  Forums: http://sourceforge.net/forum/?group_id=92496
 
   This software is provided 'as-is', without any express or implied
   warranty. In no event will the authors be held liable for any damages

--- a/arcball.cpp
+++ b/arcball.cpp
@@ -10,8 +10,8 @@
      Feb 1998, Paul Rademacher (rademach@cs.unc.edu)
      Oct 2003, Nigel Stewart - GLUI Code Cleaning
 
-  WWW:    http://sourceforge.net/projects/glui/
-  Forums: http://sourceforge.net/forum/?group_id=92496
+  WWW:    https://github.com/libglui/glui
+  Issues: https://github.com/libglui/glui/issues
 
   This software is provided 'as-is', without any express or implied
   warranty. In no event will the authors be held liable for any damages
@@ -37,7 +37,7 @@
 
 
 /**************************************** Arcball::Arcball() ****/
-/* Default (void) constructor for Arcball                         */
+/* Default () constructor for Arcball                         */
 
 Arcball::Arcball()
 {

--- a/arcball.cpp
+++ b/arcball.cpp
@@ -10,8 +10,8 @@
      Feb 1998, Paul Rademacher (rademach@cs.unc.edu)
      Oct 2003, Nigel Stewart - GLUI Code Cleaning
 
-  WWW:    https://github.com/libglui/glui
-  Issues: https://github.com/libglui/glui/issues
+  WWW:    http://sourceforge.net/projects/glui/
+  Forums: http://sourceforge.net/forum/?group_id=92496
 
   This software is provided 'as-is', without any express or implied
   warranty. In no event will the authors be held liable for any damages

--- a/example/example1.cpp
+++ b/example/example1.cpp
@@ -22,7 +22,7 @@ int   main_window;
 
 /***************************************** myGlutIdle() ***********/
 
-void myGlutIdle( void )
+void myGlutIdle()
 {
   /* According to the GLUT specification, the current window is 
      undefined during an idle callback.  So we need to explicitly change
@@ -52,7 +52,7 @@ void myGlutReshape( int x, int y )
 
 /***************************************** myGlutDisplay() *****************/
 
-void myGlutDisplay( void )
+void myGlutDisplay()
 {
   static float rotationX = 0.0, rotationY = 0.0;
 

--- a/example/example2.cpp
+++ b/example/example2.cpp
@@ -127,7 +127,7 @@ void myGlutReshape( int x, int y )
 
 /***************************************** myGlutDisplay() *****************/
 
-void myGlutDisplay( void )
+void myGlutDisplay()
 {
   glClearColor( .9f, .9f, .9f, 1.0f );
   glClear( GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );

--- a/example/example3.cpp
+++ b/example/example3.cpp
@@ -190,7 +190,7 @@ void myGlutMenu( int value )
 
 /***************************************** myGlutIdle() ***********/
 
-void myGlutIdle( void )
+void myGlutIdle()
 {
   /* According to the GLUT specification, the current window is 
      undefined during an idle callback.  So we need to explicitly change
@@ -254,7 +254,7 @@ void myGlutReshape( int x, int y )
 
 /***************************************** myGlutDisplay() *****************/
 
-void myGlutDisplay( void )
+void myGlutDisplay()
 {
   glClearColor( .9f, .9f, .9f, 1.0f );
   glClear( GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );

--- a/example/example4.cpp
+++ b/example/example4.cpp
@@ -191,7 +191,7 @@ void draw_axes( float scale )
 
 /***************************************** myGlutDisplay() *****************/
 
-void myGlutDisplay( void )
+void myGlutDisplay()
 {
   glClearColor( .9f, .9f, .9f, 1.0f );
   glClear( GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );

--- a/example/example5.cpp
+++ b/example/example5.cpp
@@ -160,7 +160,7 @@ void myGlutMenu( int value )
 
 /***************************************** myGlutIdle() ***********/
 
-void myGlutIdle( void )
+void myGlutIdle()
 {
   /* According to the GLUT specification, the current window is 
      undefined during an idle callback.  So we need to explicitly change
@@ -234,7 +234,7 @@ void draw_axes( float scale )
 
 /***************************************** myGlutDisplay() *****************/
 
-void myGlutDisplay( void )
+void myGlutDisplay()
 {
   glClearColor( .9f, .9f, .9f, 1.0f );
   glClear( GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );

--- a/glui.cpp
+++ b/glui.cpp
@@ -9,8 +9,8 @@
 
   Copyright (c) 1998 Paul Rademacher
 
-  WWW:    http://sourceforge.net/projects/glui/
-  Forums: http://sourceforge.net/forum/?group_id=92496
+  WWW:    https://github.com/libglui/glui
+  Issues: https://github.com/libglui/glui/issues
 
   This software is provided 'as-is', without any express or implied
   warranty. In no event will the authors be held liable for any damages
@@ -106,7 +106,7 @@ GLUI_Master_Object GLUI_Master;
   Probably a silly routine.  Called after all event handling callbacks.
 */
 
-static void finish_drawing(void)
+static void finish_drawing()
 {
 	glFinish();
 }
@@ -216,7 +216,7 @@ void GLUI_Main::setup_default_glut_callbacks( void )
 
 /********************************************** glui_display_func() ********/
 
-void glui_display_func(void)
+void glui_display_func()
 {
   GLUI *glui;
 
@@ -447,7 +447,7 @@ void glui_visibility_func(int state)
 /********************************************** glui_idle_func() ********/
 /* Send idle event to each glui, then to the main window            */
 
-void glui_idle_func(void)
+void glui_idle_func()
 {
   GLUI *glui;
 
@@ -895,7 +895,7 @@ void    GLUI_Main::visibility(int state)
 
 /****************************** GLUI_Main::idle() **************/
 
-void    GLUI_Main::idle(void)
+void    GLUI_Main::idle()
 {
   /*** Pass the idle event onto the active control, if any ***/
 
@@ -1426,7 +1426,7 @@ GLUI_Control  *GLUI_Main::find_prev_control( GLUI_Control *control )
 
 /************************* GLUI_Master_Object::set_glutIdleFunc() ***********/
 
-void    GLUI_Master_Object::set_glutIdleFunc(void (*f)(void))
+void    GLUI_Master_Object::set_glutIdleFunc(void (*f)())
 {
   glut_idle_CB = f;
   GLUI_Master.glui_setIdleFuncIfNecessary();

--- a/glui.cpp
+++ b/glui.cpp
@@ -199,7 +199,7 @@ void GLUI_Main::create_subwindow( int parent_window, int window_alignment )
 
 /**************************** GLUI_Main::setup_default_glut_callbacks() *****/
 
-void GLUI_Main::setup_default_glut_callbacks( void )
+void GLUI_Main::setup_default_glut_callbacks()
 {
   glutDisplayFunc( glui_display_func );
   glutReshapeFunc( glui_reshape_func );
@@ -542,7 +542,7 @@ GLUI  *GLUI_Master_Object::find_glui_by_window_id( int window_id )
 
 /******************************************** GLUI_Main::display() **********/
 
-void    GLUI_Main::display( void )
+void    GLUI_Main::display()
 {
   int       win_w, win_h;
 
@@ -918,7 +918,7 @@ void    GLUI_Main::idle()
   }
 }
 
-int  GLUI_Main::needs_idle( void )
+int  GLUI_Main::needs_idle()
 {
   return active_control != NULL && active_control->needs_idle();
 }
@@ -982,7 +982,7 @@ GLUI_Control  *GLUI_Main::find_control( int x, int y )
 
 /************************************* GLUI_Main::pack_controls() ***********/
 
-void      GLUI_Main::pack_controls( void )
+void      GLUI_Main::pack_controls()
 {
   main_panel->pack(0,0);
 
@@ -1053,7 +1053,7 @@ void   GLUI::set_main_gfx_window( int window_id )
 
 /********************************* GLUI_Main::post_update_main_gfx() ********/
 
-void   GLUI_Main::post_update_main_gfx( void )
+void   GLUI_Main::post_update_main_gfx()
 {
   int old_window;
 
@@ -1088,7 +1088,7 @@ bool	     GLUI_Main::should_redraw_now(GLUI_Control *ctl)
 
 /********************************* GLUI_Main::set_current_draw_buffer() ********/
 
-int          GLUI_Main::set_current_draw_buffer( void )
+int          GLUI_Main::set_current_draw_buffer()
 {
   /* Save old buffer */
   GLint state;
@@ -1112,7 +1112,7 @@ void         GLUI_Main::restore_draw_buffer( int buffer_state )
 
 /******************************************** GLUI_Main::GLUI_Main() ********/
 
-GLUI_Main::GLUI_Main( void )
+GLUI_Main::GLUI_Main()
 {
   mouse_button_down       = false;
   w                       = 0;
@@ -1240,7 +1240,7 @@ void         GLUI_Main::activate_control( GLUI_Control *control, int how )
 
 /************************* GLUI_Main::deactivate_current_control() **********/
 
-void         GLUI_Main::deactivate_current_control( void )
+void         GLUI_Main::deactivate_current_control()
 {
   int orig;
 
@@ -1435,7 +1435,7 @@ void    GLUI_Master_Object::set_glutIdleFunc(void (*f)())
 
 /**************************************** GLUI::disable() ********************/
 
-void   GLUI::disable( void )
+void   GLUI::disable()
 {
   deactivate_current_control();
   main_panel->disable();
@@ -1444,7 +1444,7 @@ void   GLUI::disable( void )
 
 /******************************************** GLUI::sync_live() **************/
 
-void   GLUI::sync_live( void )
+void   GLUI::sync_live()
 {
   main_panel->sync_live(true, true);
 }
@@ -1452,7 +1452,7 @@ void   GLUI::sync_live( void )
 
 /********************************* GLUI_Master_Object::sync_live_all() *****/
 
-void   GLUI_Master_Object::sync_live_all( void )
+void   GLUI_Master_Object::sync_live_all()
 {
   GLUI *glui;
 
@@ -1468,7 +1468,7 @@ void   GLUI_Master_Object::sync_live_all( void )
 
 /************************************* GLUI_Master_Object::close() **********/
 
-void   GLUI_Master_Object::close_all( void )
+void   GLUI_Master_Object::close_all()
 {
   GLUI *glui;
 
@@ -1484,7 +1484,7 @@ void   GLUI_Master_Object::close_all( void )
 
 /************************************* GLUI_Main::close_internal() **********/
 
-void   GLUI_Main::close_internal( void )
+void   GLUI_Main::close_internal()
 {
   glutDestroyWindow(glutGetWindow()); /** Close this window **/
 
@@ -1511,7 +1511,7 @@ void   GLUI_Main::close_internal( void )
 
 /************************************************** GLUI::close() **********/
 
-void   GLUI::close( void )
+void   GLUI::close()
 {
   int   old_glut_window;
 
@@ -1527,7 +1527,7 @@ void   GLUI::close( void )
 
 /************************** GLUI_Main::check_subwindow_position() **********/
 
-void   GLUI_Main::check_subwindow_position( void )
+void   GLUI_Main::check_subwindow_position()
 {
   /*** Reposition this window if subwindow ***/
   if ( TEST_AND( this->flags, GLUI_SUBWINDOW ) ) {
@@ -1626,7 +1626,7 @@ void   GLUI_Main::check_subwindow_position( void )
 /* This gets called by the user from a GLUT reshape callback.  So we look */
 /* for subwindows that belong to the current window                   */
 
-void  GLUI_Master_Object::reshape( void )
+void  GLUI_Master_Object::reshape()
 {
   GLUI *glui;
   int   current_window;
@@ -1899,7 +1899,7 @@ void  GLUI_Master_Object::set_left_button_glut_menu_control(
 
 /******************************* GLUI_Main::set_ortho_projection() **********/
 
-void  GLUI_Main::set_ortho_projection( void )
+void  GLUI_Main::set_ortho_projection()
 {
   int win_h, win_w;
 
@@ -1928,7 +1928,7 @@ void  GLUI_Main::set_ortho_projection( void )
 
 /******************************* GLUI_Main::set_viewport() **********/
 
-void  GLUI_Main::set_viewport( void )
+void  GLUI_Main::set_viewport()
 {
   glViewport( 0, 0, main_panel->w, main_panel->h );
 }
@@ -1936,7 +1936,7 @@ void  GLUI_Main::set_viewport( void )
 
 /****************************** GLUI_Main::refresh() ****************/
 
-void    GLUI_Main::refresh( void )
+void    GLUI_Main::refresh()
 {
   int orig;
 
@@ -2030,7 +2030,7 @@ void     GLUI_Master_Object::get_viewport_area( int *x, int *y,
 
 /*****************GLUI_Master_Object::auto_set_main_gfx_viewport() **********/
 
-void           GLUI_Master_Object::auto_set_viewport( void )
+void           GLUI_Master_Object::auto_set_viewport()
 {
   int x, y, w, h;
 
@@ -2042,7 +2042,7 @@ void           GLUI_Master_Object::auto_set_viewport( void )
 
 /***************************************** GLUI::show() **********************/
 
-void            GLUI::show( void )
+void            GLUI::show()
 {
   int orig_window;
 
@@ -2057,7 +2057,7 @@ void            GLUI::show( void )
 
 /***************************************** GLUI::hide() **********************/
 
-void            GLUI::hide( void )
+void            GLUI::hide()
 {
   int orig_window;
 
@@ -2084,7 +2084,7 @@ GLUI_DrawingSentinal::~GLUI_DrawingSentinal() {
 }
 
 
-void GLUI_Master_Object::glui_setIdleFuncIfNecessary( void )
+void GLUI_Master_Object::glui_setIdleFuncIfNecessary()
 {
   GLUI *glui;
 

--- a/glui.cpp
+++ b/glui.cpp
@@ -9,8 +9,8 @@
 
   Copyright (c) 1998 Paul Rademacher
 
-  WWW:    https://github.com/libglui/glui
-  Issues: https://github.com/libglui/glui/issues
+  WWW:    http://sourceforge.net/projects/glui/
+  Forums: http://sourceforge.net/forum/?group_id=92496
 
   This software is provided 'as-is', without any express or implied
   warranty. In no event will the authors be held liable for any damages

--- a/glui_add_controls.cpp
+++ b/glui_add_controls.cpp
@@ -143,7 +143,7 @@ GLUI_Button   *GLUI::add_button_to_panel( GLUI_Panel *panel,
 
 /********************************** GLUI::add_separator() ************/
 
-void  GLUI::add_separator( void )
+void  GLUI::add_separator()
 {
   add_separator_to_panel( main_panel );
 }

--- a/glui_button.cpp
+++ b/glui_button.cpp
@@ -112,7 +112,7 @@ void    GLUI_Button::draw( int x, int y )
 
 /************************************** GLUI_Button::draw_pressed() ******/
 
-void   GLUI_Button::draw_pressed( void )
+void   GLUI_Button::draw_pressed()
 {
   glColor3f( 0.0, 0.0, 0.0 );
 
@@ -172,7 +172,7 @@ void     GLUI_Button::draw_text( int sunken )
 
 /************************************** GLUI_Button::update_size() **********/
 
-void   GLUI_Button::update_size( void )
+void   GLUI_Button::update_size()
 {
   int text_size;
 

--- a/glui_checkbox.cpp
+++ b/glui_checkbox.cpp
@@ -136,7 +136,7 @@ void    GLUI_Checkbox::draw( int x, int y )
 
 /**************************** GLUI_Checkbox::draw_active_area() **************/
 
-void    GLUI_Checkbox::draw_active_area( void )
+void    GLUI_Checkbox::draw_active_area()
 {
   GLUI_DRAWINGSENTINAL_IDIOM
   int text_width, left, right;
@@ -164,7 +164,7 @@ void    GLUI_Checkbox::draw_active_area( void )
 
 /************************************ GLUI_Checkbox::update_size() **********/
 
-void   GLUI_Checkbox::update_size( void )
+void   GLUI_Checkbox::update_size()
 {
   int text_size;
 

--- a/glui_commandline.cpp
+++ b/glui_commandline.cpp
@@ -79,7 +79,7 @@ int    GLUI_CommandLine::key_handler( unsigned char key,int modifiers )
 
 /****************************** GLUI_CommandLine::deactivate() **********/
 
-void    GLUI_CommandLine::deactivate( void )
+void    GLUI_CommandLine::deactivate()
 {
   // if the commit_flag is set, add the current command to
   // history and call deactivate as normal
@@ -177,7 +177,7 @@ void    GLUI_CommandLine::add_to_history( const char *cmd )
 
 /**************************** GLUI_CommandLine::reset_history() ********/
 
-void    GLUI_CommandLine::reset_history( void )
+void    GLUI_CommandLine::reset_history()
 {
   oldest_hist = newest_hist = curr_hist = 0;
 }

--- a/glui_control.cpp
+++ b/glui_control.cpp
@@ -10,8 +10,8 @@
 
   Copyright (c) 1998 Paul Rademacher
 
-  WWW:    https://github.com/libglui/glui
-  Issues: https://github.com/libglui/glui/issues
+  WWW:    http://sourceforge.net/projects/glui/
+  Forums: http://sourceforge.net/forum/?group_id=92496
 
   This software is provided 'as-is', without any express or implied
   warranty. In no event will the authors be held liable for any damages

--- a/glui_control.cpp
+++ b/glui_control.cpp
@@ -10,8 +10,8 @@
 
   Copyright (c) 1998 Paul Rademacher
 
-  WWW:    http://sourceforge.net/projects/glui/
-  Forums: http://sourceforge.net/forum/?group_id=92496
+  WWW:    https://github.com/libglui/glui
+  Issues: https://github.com/libglui/glui/issues
 
   This software is provided 'as-is', without any express or implied
   warranty. In no event will the authors be held liable for any damages
@@ -38,14 +38,14 @@ int _glui_draw_border_only = 0;
 /*************************** Drawing Utility routines *********************/
 
 /* Redraw this control. */
-void	      GLUI_Control::redraw(void) {
+void	      GLUI_Control::redraw() {
     if (glui==NULL || hidden) return;
     if (glui->should_redraw_now(this))
       translate_and_draw_front();
 }
 
 /** Redraw everybody in our window. */
-void	     GLUI_Control::redraw_window(void) {
+void	     GLUI_Control::redraw_window() {
   if (glui==NULL || hidden) return;
   if ( glui->get_glut_window_id() == -1 ) return;
   int orig = set_to_glut_window();

--- a/glui_control.cpp
+++ b/glui_control.cpp
@@ -71,7 +71,7 @@ void GLUI_Control::translate_and_draw_front()
 
 /********** GLUI_Control::set_to_bkgd_color() ********/
 
-void GLUI_Control::set_to_bkgd_color( void )
+void GLUI_Control::set_to_bkgd_color()
 {
   if ( NOT glui )
     return;
@@ -324,7 +324,7 @@ int GLUI_Control::char_width(char c)
 
 /*************** GLUI_Control::get_font() **********/
 
-void *GLUI_Control::get_font( void )
+void *GLUI_Control::get_font()
 {
   /*** Does this control have its own font? ***/
   if ( this->font != NULL )

--- a/glui_edittext.cpp
+++ b/glui_edittext.cpp
@@ -468,7 +468,7 @@ void    GLUI_EditText::activate( int how )
 
 /****************************** GLUI_EditText::deactivate() **********/
 
-void    GLUI_EditText::deactivate( void )
+void    GLUI_EditText::deactivate()
 {
   int    new_int_val;
   float  new_float_val;
@@ -574,7 +574,7 @@ void    GLUI_EditText::draw( int x, int y )
 
 /************************** GLUI_EditText::update_substring_bounds() *********/
 
-int    GLUI_EditText::update_substring_bounds( void )
+int    GLUI_EditText::update_substring_bounds()
 {
   int box_width;
   int text_len = (int)text.length();
@@ -640,7 +640,7 @@ int    GLUI_EditText::update_substring_bounds( void )
 
 /********************************* GLUI_EditText::update_x_offsets() *********/
 
-void    GLUI_EditText::update_x_offsets( void )
+void    GLUI_EditText::update_x_offsets()
 {
 }
 
@@ -788,7 +788,7 @@ int  GLUI_EditText::find_insertion_pt( int x, int y )
 
 /******************************** GLUI_EditText::draw_insertion_pt() *********/
 
-void     GLUI_EditText::draw_insertion_pt( void )
+void     GLUI_EditText::draw_insertion_pt()
 {
   int curr_x, i;
 
@@ -854,7 +854,7 @@ int  GLUI_EditText::substring_width( int start, int end )
 
 /***************************** GLUI_EditText::update_and_draw_text() ********/
 
-void   GLUI_EditText::update_and_draw_text( void )
+void   GLUI_EditText::update_and_draw_text()
 {
   if ( NOT can_draw() )
     return;
@@ -994,7 +994,7 @@ void   GLUI_EditText::clear_substring( int start, int end )
 
 /************************************ GLUI_EditText::update_size() **********/
 
-void   GLUI_EditText::update_size( void )
+void   GLUI_EditText::update_size()
 {
   int text_size, delta;
 
@@ -1133,7 +1133,7 @@ void   GLUI_EditText::set_int_limits( int low, int high, int limit_type )
 
 /************************************ GLUI_EditText::set_numeric_text() ******/
 
-void    GLUI_EditText::set_numeric_text( void )
+void    GLUI_EditText::set_numeric_text()
 {
   char buf_num[200];
   int  i, text_len;

--- a/glui_list.cpp
+++ b/glui_list.cpp
@@ -188,7 +188,7 @@ void    GLUI_List::activate( int how )
 
 /****************************** GLUI_List::deactivate() **********/
 
-void    GLUI_List::deactivate( void )
+void    GLUI_List::deactivate()
 {
   active = false;
   redraw();
@@ -357,7 +357,7 @@ int  GLUI_List::substring_width( const char *t, int start, int end )
 
 /***************************** GLUI_List::update_and_draw_text() ********/
 
-void   GLUI_List::update_and_draw_text( void )
+void   GLUI_List::update_and_draw_text()
 {
   if ( NOT can_draw() )
     return;
@@ -399,7 +399,7 @@ int    GLUI_List::special_handler( int key,int modifiers )
 
 /************************************ GLUI_List::update_size() **********/
 
-void   GLUI_List::update_size( void )
+void   GLUI_List::update_size()
 {
   if ( NOT glui )
     return;

--- a/glui_listbox.cpp
+++ b/glui_listbox.cpp
@@ -133,7 +133,7 @@ void    GLUI_Listbox::draw( int x, int y )
 
 
 /************************************ GLUI_Listbox::update_si() **********/
-void   GLUI_Listbox::update_size( void )
+void   GLUI_Listbox::update_size()
 {
   recalculate_item_width();
 }
@@ -217,7 +217,7 @@ int  GLUI_Listbox::delete_item(int id)
 
 /************************************** GLUI_Listbox::sort_items() **********/
 
-int  GLUI_Listbox::sort_items( void )
+int  GLUI_Listbox::sort_items()
 {
   return false;
 }
@@ -417,9 +417,9 @@ int    GLUI_Listbox::special_handler( int key,int modifiers )
 }
 
 
-/************************* GLUI_Listbox::recalculate_item_width( void ) ***********/
+/************************* GLUI_Listbox::recalculate_item_width() ***********/
 /** Change w and return true if we need to be widened to fit the current items. */
-bool    GLUI_Listbox::recalculate_item_width( void )
+bool    GLUI_Listbox::recalculate_item_width()
 {
   int item_text_size;
 

--- a/glui_mouse_iaction.cpp
+++ b/glui_mouse_iaction.cpp
@@ -97,7 +97,7 @@ void    GLUI_Mouse_Interaction::draw( int x, int y )
 
 /************************************ GLUI_Mouse_Interaction::update_size() **********/
 
-void   GLUI_Mouse_Interaction::update_size( void )
+void   GLUI_Mouse_Interaction::update_size()
 {
   if ( NOT glui )
     return;
@@ -147,7 +147,7 @@ int    GLUI_Mouse_Interaction::special_handler( int key,int modifiers )
 
 /****************************** GLUI_Mouse_Interaction::draw_active_area() **********/
 
-void    GLUI_Mouse_Interaction::draw_active_area( void )
+void    GLUI_Mouse_Interaction::draw_active_area()
 {
   int win_h = glutGet( GLUT_WINDOW_HEIGHT ), win_w = glutGet(GLUT_WINDOW_WIDTH);
 

--- a/glui_node.cpp
+++ b/glui_node.cpp
@@ -49,7 +49,7 @@ GLUI_Node::GLUI_Node()
 /********************************************* GLUI_Node::first() *******/
 /* Returns first sibling in 'this' node's sibling list                  */
 
-GLUI_Node   *GLUI_Node::first_sibling( void )
+GLUI_Node   *GLUI_Node::first_sibling()
 {
   if ( parent_node == NULL )
     return this;           /* root node has no siblings */
@@ -61,7 +61,7 @@ GLUI_Node   *GLUI_Node::first_sibling( void )
 /******************************************** GLUI_Node::next() ********/
 /* Returns next sibling in 'this' node's sibling list                  */
 
-GLUI_Node    *GLUI_Node::next( void )
+GLUI_Node    *GLUI_Node::next()
 {
   return next_sibling;
 }
@@ -70,7 +70,7 @@ GLUI_Node    *GLUI_Node::next( void )
 /******************************************** GLUI_Node::prev() ********/
 /* Returns prev sibling in 'this' node's sibling list                  */
 
-GLUI_Node    *GLUI_Node::prev( void )
+GLUI_Node    *GLUI_Node::prev()
 {
   return prev_sibling;
 }
@@ -79,7 +79,7 @@ GLUI_Node    *GLUI_Node::prev( void )
 /********************************************* GLUI_Node::last() *******/
 /* Returns last sibling in 'this' node's sibling list                  */
 
-GLUI_Node   *GLUI_Node::last_sibling( void )
+GLUI_Node   *GLUI_Node::last_sibling()
 {
   if ( parent_node == NULL )
     return this;            /* root node has no siblings */
@@ -174,7 +174,7 @@ void   GLUI_Node::link_this_to_sibling_prev( GLUI_Node *sibling )
 
 /**************************************** GLUI_Node::unlink() **************/
 
-void   GLUI_Node::unlink( void )
+void   GLUI_Node::unlink()
 {
   /* Unlink from prev sibling */
   if ( this->prev_sibling != NULL ) {

--- a/glui_panel.cpp
+++ b/glui_panel.cpp
@@ -167,7 +167,7 @@ void    GLUI_Panel::set_type( int new_type )
 
 /************************************** GLUI_Panel::update_size() **********/
 
-void   GLUI_Panel::update_size( void )
+void   GLUI_Panel::update_size()
 {
   int text_size;
 

--- a/glui_radio.cpp
+++ b/glui_radio.cpp
@@ -265,7 +265,7 @@ void    GLUI_RadioButton::draw( int x, int y )
 
 /************************************ GLUI_RadioButton::draw_checked() ******/
 
-void   GLUI_RadioButton::draw_checked( void )
+void   GLUI_RadioButton::draw_checked()
 {
   GLUI_DRAWINGSENTINAL_IDIOM
   if ( enabled )
@@ -278,7 +278,7 @@ void   GLUI_RadioButton::draw_checked( void )
 
 /*********************************** GLUI_RadioButton::draw_unchecked() ******/
 
-void   GLUI_RadioButton::draw_unchecked( void )
+void   GLUI_RadioButton::draw_unchecked()
 {
   GLUI_DRAWINGSENTINAL_IDIOM
 
@@ -292,7 +292,7 @@ void   GLUI_RadioButton::draw_unchecked( void )
 
 /**************************************** GLUI_RadioButton::draw_O() ********/
 
-void   GLUI_RadioButton::draw_O( void )
+void   GLUI_RadioButton::draw_O()
 {
   GLUI_DRAWINGSENTINAL_IDIOM
   int i, j;
@@ -307,7 +307,7 @@ void   GLUI_RadioButton::draw_O( void )
 
 /******************************** GLUI_RadioButton::update_size() **********/
 
-void   GLUI_RadioButton::update_size( void )
+void   GLUI_RadioButton::update_size()
 {
   int text_size;
 
@@ -323,7 +323,7 @@ void   GLUI_RadioButton::update_size( void )
 
 /************************* GLUI_RadioButton::draw_active_area() **************/
 
-void    GLUI_RadioButton::draw_active_area( void )
+void    GLUI_RadioButton::draw_active_area()
 {
   GLUI_DRAWINGSENTINAL_IDIOM
   int text_width, left, right;

--- a/glui_rollout.cpp
+++ b/glui_rollout.cpp
@@ -55,7 +55,7 @@ GLUI_Rollout::GLUI_Rollout( GLUI_Node *parent, const char *name,
 
 /****************************** GLUI_Rollout::open() **********/
 
-void    GLUI_Rollout::open( void )
+void    GLUI_Rollout::open()
 {
   if ( NOT glui )
     return;
@@ -82,7 +82,7 @@ void    GLUI_Rollout::open( void )
 
 /****************************** GLUI_Rollout::close() **********/
 
-void    GLUI_Rollout::close( void )
+void    GLUI_Rollout::close()
 {
   if ( NOT glui )
     return;
@@ -237,7 +237,7 @@ void   GLUI_Rollout::draw( int x, int y )
 
 /***************************** GLUI_Rollout::update_size() **********/
 
-void   GLUI_Rollout::update_size( void )
+void   GLUI_Rollout::update_size()
 {
   int text_size;
 
@@ -253,7 +253,7 @@ void   GLUI_Rollout::update_size( void )
 
 /**************************** GLUI_Rollout::draw_pressed() ***********/
 
-void   GLUI_Rollout::draw_pressed( void )
+void   GLUI_Rollout::draw_pressed()
 {
   int left, right, top, bottom;
 

--- a/glui_rotation.cpp
+++ b/glui_rotation.cpp
@@ -99,7 +99,7 @@ int    GLUI_Rotation::iaction_mouse_held_down_handler( int local_x, int local_y,
 
 /******************** GLUI_Rotation::iaction_draw_active_area_persp() **************/
 
-void    GLUI_Rotation::iaction_draw_active_area_persp( void )
+void    GLUI_Rotation::iaction_draw_active_area_persp()
 {
   /********** arcball *******/
   copy_float_array_to_ball();
@@ -130,7 +130,7 @@ void    GLUI_Rotation::iaction_draw_active_area_persp( void )
 
 /******************** GLUI_Rotation::iaction_draw_active_area_ortho() **********/
 
-void    GLUI_Rotation::iaction_draw_active_area_ortho( void )
+void    GLUI_Rotation::iaction_draw_active_area_ortho()
 {
   float radius;
   radius = (float)(h-22)/2.0;  /*MIN((float)w/2.0, (float)h/2.0);  */
@@ -184,7 +184,7 @@ int    GLUI_Rotation::iaction_special_handler( int key,int modifiers )
 
 /********************************** GLUI_Rotation::init_ball() **********/
 
-void  GLUI_Rotation::init_ball( void )
+void  GLUI_Rotation::init_ball()
 {
   /*printf( "%f %f %f", float( MIN(w/2,h/2)), (float) w/2, (float) h/2 );              */
 
@@ -198,7 +198,7 @@ void  GLUI_Rotation::init_ball( void )
 
 /****************************** GLUI_Rotation::setup_texture() *********/
 
-void GLUI_Rotation::setup_texture( void )
+void GLUI_Rotation::setup_texture()
 {
   static GLuint tex=0u;
   GLenum t=GL_TEXTURE_2D;
@@ -264,7 +264,7 @@ void GLUI_Rotation::setup_texture( void )
 
 /****************************** GLUI_Rotation::setup_lights() ***********/
 
-void    GLUI_Rotation::setup_lights( void )
+void    GLUI_Rotation::setup_lights()
 {
   glEnable( GL_LIGHTING );
   /*  if ( enabled )
@@ -317,7 +317,7 @@ void    GLUI_Rotation::draw_ball( float radius )
 
 /****************************** GLUI_Rotation::reset() **********/
 
-void  GLUI_Rotation::reset( void )
+void  GLUI_Rotation::reset()
 {
   ball->init(); /** reset quaternion, etc. **/
   ball->set_params( vec2( (float)(w/2), (float)((h-18)/2)),
@@ -335,7 +335,7 @@ void  GLUI_Rotation::reset( void )
 
 /****************************** GLUI_Rotation::needs_idle() *********/
 
-bool GLUI_Rotation::needs_idle( void ) const
+bool GLUI_Rotation::needs_idle() const
 {
   return can_spin;
 }
@@ -343,7 +343,7 @@ bool GLUI_Rotation::needs_idle( void ) const
 
 /****************************** GLUI_Rotation::idle() ***************/
 
-void        GLUI_Rotation::idle( void )
+void        GLUI_Rotation::idle()
 {
   spinning = ball->is_spinning?true:false;
 
@@ -371,7 +371,7 @@ void        GLUI_Rotation::idle( void )
 
 /********************** GLUI_Rotation::copy_float_array_to_ball() *********/
 
-void     GLUI_Rotation::copy_float_array_to_ball( void )
+void     GLUI_Rotation::copy_float_array_to_ball()
 {
   int i;
   float *fp_src, *fp_dst;
@@ -390,7 +390,7 @@ void     GLUI_Rotation::copy_float_array_to_ball( void )
 
 /********************** GLUI_Rotation::copy_ball_to_float_array() *********/
 
-void     GLUI_Rotation::copy_ball_to_float_array( void )
+void     GLUI_Rotation::copy_ball_to_float_array()
 {
   mat4 tmp_rot;
   tmp_rot = *ball->rot_ptr;
@@ -455,7 +455,7 @@ NO! WVB
 
 /************** GLUI_Rotation::common_init() ********************/
 
-void GLUI_Rotation::common_init( void )
+void GLUI_Rotation::common_init()
 {
   glui_format_str( name, "Rotation: %p", this );
 //  type                = GLUI_CONTROL_ROTATION;

--- a/glui_scrollbar.cpp
+++ b/glui_scrollbar.cpp
@@ -86,7 +86,7 @@ GLUI_Scrollbar::GLUI_Scrollbar( GLUI_Node *parent, const char *name,
 }
 
 /****************************** GLUI_Scrollbar::common_init() **********/
-void GLUI_Scrollbar::common_init(void)
+void GLUI_Scrollbar::common_init()
 {
    horizontal	= true;
    h		= GLUI_SCROLL_ARROW_HEIGHT;

--- a/glui_scrollbar.cpp
+++ b/glui_scrollbar.cpp
@@ -527,7 +527,7 @@ int    GLUI_Scrollbar::special_handler( int key,int modifiers )
 
 /************************************ GLUI_Scrollbar::update_size() **********/
 
-void   GLUI_Scrollbar::update_size( void )
+void   GLUI_Scrollbar::update_size()
 {
   if (horizontal) {
     h = GLUI_SCROLL_ARROW_HEIGHT;
@@ -592,7 +592,7 @@ int    GLUI_Scrollbar::find_arrow( int local_x, int local_y )
 
 /***************************************** GLUI_Scrollbar::do_click() **********/
 
-void    GLUI_Scrollbar::do_click( void )
+void    GLUI_Scrollbar::do_click()
 {
   int    direction = 0;
 
@@ -687,7 +687,7 @@ void    GLUI_Scrollbar::do_drag( int x, int y )
 
 /***************************************** GLUI_Scrollbar::needs_idle() ******/
 
-bool GLUI_Scrollbar::needs_idle( void ) const
+bool GLUI_Scrollbar::needs_idle() const
 {
   if  (state == GLUI_SCROLL_STATE_UP OR state == GLUI_SCROLL_STATE_DOWN ) {
     return true;
@@ -699,7 +699,7 @@ bool GLUI_Scrollbar::needs_idle( void ) const
 
 /***************************************** GLUI_Scrollbar::idle() **********/
 
-void    GLUI_Scrollbar::idle( void )
+void    GLUI_Scrollbar::idle()
 {
   if ( NOT needs_idle() )
     return;
@@ -710,7 +710,7 @@ void    GLUI_Scrollbar::idle( void )
 
 /************************************ GLUI_Scrollbar::do_callbacks() **********/
 
-void    GLUI_Scrollbar::do_callbacks( void )
+void    GLUI_Scrollbar::do_callbacks()
 {
 
   /*    *******************************************/
@@ -819,7 +819,7 @@ void   GLUI_Scrollbar::set_int_limits( int low, int high, int limit_type )
 
 /*********************************** GLUI_Scrollbar::reset_growth() *************/
 
-void    GLUI_Scrollbar::reset_growth( void )
+void    GLUI_Scrollbar::reset_growth()
 {
   growth = fabs(float_max - float_min) / float(GLUI_SCROLL_GROWTH_STEPS);
   if (data_type == GLUI_SCROLL_INT && growth<1) growth=1;
@@ -828,7 +828,7 @@ void    GLUI_Scrollbar::reset_growth( void )
 
 /******************************* GLUI_Scrollbar::increase_growth() *************/
 
-void    GLUI_Scrollbar::increase_growth( void )
+void    GLUI_Scrollbar::increase_growth()
 {
   float range=0;
   if (data_type==GLUI_SCROLL_FLOAT)

--- a/glui_spinner.cpp
+++ b/glui_spinner.cpp
@@ -360,7 +360,7 @@ void   GLUI_Spinner::set_int_val( int new_val )
 
 /************************************ GLUI_Spinner::update_size() **********/
 
-void   GLUI_Spinner::update_size( void )
+void   GLUI_Spinner::update_size()
 {
   if (!edittext) return;
   /*edittext->w = this->w - GLUI_SPINNER_ARROW_WIDTH-3;              */
@@ -394,7 +394,7 @@ int    GLUI_Spinner::find_arrow( int local_x, int local_y )
 
 /***************************************** GLUI_Spinner::do_click() **********/
 
-void    GLUI_Spinner::do_click( void )
+void    GLUI_Spinner::do_click()
 {
   int    direction = 0;
   float  incr;
@@ -470,7 +470,7 @@ void    GLUI_Spinner::do_drag( int x, int y )
 
 /***************************************** GLUI_Spinner::needs_idle() ******/
 
-bool GLUI_Spinner::needs_idle( void ) const
+bool GLUI_Spinner::needs_idle() const
 {
   if  (state == GLUI_SPINNER_STATE_UP OR state == GLUI_SPINNER_STATE_DOWN ) {
     return true;
@@ -482,7 +482,7 @@ bool GLUI_Spinner::needs_idle( void ) const
 
 /***************************************** GLUI_Spinner::idle() **********/
 
-void    GLUI_Spinner::idle( void )
+void    GLUI_Spinner::idle()
 {
   if ( NOT needs_idle() )
     return;
@@ -493,7 +493,7 @@ void    GLUI_Spinner::idle( void )
 
 /************************************ GLUI_Spinner::do_callbacks() **********/
 
-void    GLUI_Spinner::do_callbacks( void )
+void    GLUI_Spinner::do_callbacks()
 {
   /*** This is not necessary, b/c edittext automatically updates us ***/
   if ( NOT edittext )
@@ -544,7 +544,7 @@ void   GLUI_Spinner::set_int_limits( int low, int high, int limit_type )
 
 /*********************************** GLUI_Spinner:reset_growth() *************/
 
-void    GLUI_Spinner::reset_growth( void )
+void    GLUI_Spinner::reset_growth()
 {
   float lo, hi;
 
@@ -575,7 +575,7 @@ void    GLUI_Spinner::reset_growth( void )
 
 /******************************* GLUI_Spinner:increase_growth() *************/
 
-void    GLUI_Spinner::increase_growth( void )
+void    GLUI_Spinner::increase_growth()
 {
   float hi = 0.0,lo = 0.0;
 
@@ -597,7 +597,7 @@ void    GLUI_Spinner::increase_growth( void )
 
 /*************************************** GLUI_Spinner:get_text() *************/
 
-const char    *GLUI_Spinner::get_text( void )
+const char    *GLUI_Spinner::get_text()
 {
   if (edittext)
     return edittext->text.c_str();
@@ -608,7 +608,7 @@ const char    *GLUI_Spinner::get_text( void )
 
 /********************************** GLUI_Spinner:get_float_val() *************/
 
-float    GLUI_Spinner::get_float_val( void )
+float    GLUI_Spinner::get_float_val()
 {
   if (edittext)
     return edittext->float_val;
@@ -619,7 +619,7 @@ float    GLUI_Spinner::get_float_val( void )
 
 /********************************** GLUI_Spinner:get_int_val() *************/
 
-int    GLUI_Spinner::get_int_val( void )
+int    GLUI_Spinner::get_int_val()
 {
   if (edittext)
     return edittext->int_val;

--- a/glui_statictext.cpp
+++ b/glui_statictext.cpp
@@ -62,7 +62,7 @@ void    GLUI_StaticText::set_text( const char *text )
 
 /************************************ GLUI_StaticText::update_size() **********/
 
-void   GLUI_StaticText::update_size( void )
+void   GLUI_StaticText::update_size()
 {
   int text_size;
 
@@ -78,7 +78,7 @@ void   GLUI_StaticText::update_size( void )
 
 /****************************** GLUI_StaticText::draw_text() **********/
 
-void    GLUI_StaticText::draw_text( void )
+void    GLUI_StaticText::draw_text()
 {
   if ( NOT can_draw() )
     return;
@@ -90,7 +90,7 @@ void    GLUI_StaticText::draw_text( void )
 
 /****************************** GLUI_StaticText::erase_text() **********/
 
-void    GLUI_StaticText::erase_text( void )
+void    GLUI_StaticText::erase_text()
 {
   if ( NOT can_draw() )
     return;

--- a/glui_textbox.cpp
+++ b/glui_textbox.cpp
@@ -318,7 +318,7 @@ int    GLUI_TextBox::key_handler( unsigned char key,int modifiers )
 
 /****************************** GLUI_TextBox::enable() **********/
 
-void GLUI_TextBox::enable( void )
+void GLUI_TextBox::enable()
 {
   GLUI_Control::enable();
   if (scrollbar) scrollbar->enable();
@@ -326,7 +326,7 @@ void GLUI_TextBox::enable( void )
 
 /****************************** GLUI_TextBox::disable() **********/
 
-void GLUI_TextBox::disable( void )
+void GLUI_TextBox::disable()
 {
   GLUI_Control::disable();
   if (scrollbar) scrollbar->disable();
@@ -355,7 +355,7 @@ void    GLUI_TextBox::activate( int how )
 
 /****************************** GLUI_TextBox::deactivate() **********/
 
-void    GLUI_TextBox::deactivate( void )
+void    GLUI_TextBox::deactivate()
 {
   active = false;
 
@@ -495,7 +495,7 @@ void    GLUI_TextBox::draw( int x, int y )
 
 /************************** GLUI_TextBox::update_substring_bounds() *********/
 
-int    GLUI_TextBox::update_substring_bounds( void )
+int    GLUI_TextBox::update_substring_bounds()
 {
   int box_width;
   int text_len = text.length();
@@ -560,7 +560,7 @@ int    GLUI_TextBox::update_substring_bounds( void )
 
 /********************************* GLUI_TextBox::update_x_offsets() *********/
 
-void    GLUI_TextBox::update_x_offsets( void )
+void    GLUI_TextBox::update_x_offsets()
 {
 }
 
@@ -761,7 +761,7 @@ int GLUI_TextBox::get_box_width()
 
 /******************************** GLUI_TextBox::draw_insertion_pt() *********/
 
-void     GLUI_TextBox::draw_insertion_pt( void )
+void     GLUI_TextBox::draw_insertion_pt()
 {
   int curr_x, box_width, text_length, eol, sol, line;
 
@@ -878,7 +878,7 @@ int  GLUI_TextBox::substring_width( int start, int end, int initial_width )
 
 /***************************** GLUI_TextBox::update_and_draw_text() ********/
 
-void   GLUI_TextBox::update_and_draw_text( void )
+void   GLUI_TextBox::update_and_draw_text()
 {
   //update_substring_bounds();
   /*  printf( "ss: %d/%d\n", substring_start, substring_end );                  */
@@ -1031,7 +1031,7 @@ void   GLUI_TextBox::clear_substring( int start, int end )
 
 /************************************ GLUI_TextBox::update_size() **********/
 
-void   GLUI_TextBox::update_size( void )
+void   GLUI_TextBox::update_size()
 {
   if ( NOT glui )
     return;

--- a/glui_translation.cpp
+++ b/glui_translation.cpp
@@ -186,14 +186,14 @@ int    GLUI_Translation::iaction_mouse_held_down_handler( int local_x, int local
 
 /******************** GLUI_Translation::iaction_draw_active_area_persp() **************/
 
-void    GLUI_Translation::iaction_draw_active_area_persp( void )
+void    GLUI_Translation::iaction_draw_active_area_persp()
 {
 }
 
 
 /******************** GLUI_Translation::iaction_draw_active_area_ortho() **********/
 
-void    GLUI_Translation::iaction_draw_active_area_ortho( void )
+void    GLUI_Translation::iaction_draw_active_area_ortho()
 {
   /********* Draw emboss circles around arcball control *********/
   float radius;

--- a/glui_tree.cpp
+++ b/glui_tree.cpp
@@ -56,7 +56,7 @@ GLUI_Tree::GLUI_Tree(GLUI_Node *parent, const char *name,
 
 /****************************** GLUI_Tree::open() **********/
 
-void GLUI_Tree::open( void )
+void GLUI_Tree::open()
 {
   if ( is_open )
     return;
@@ -80,7 +80,7 @@ void GLUI_Tree::open( void )
 
 /****************************** GLUI_Tree::close() **********/
 
-void    GLUI_Tree::close( void )
+void    GLUI_Tree::close()
 {
   if ( NOT glui )
     return;
@@ -245,7 +245,7 @@ void   GLUI_Tree::draw( int x, int y )
 
 /***************************** GLUI_Tree::update_size() **********/
 
-void   GLUI_Tree::update_size( void )
+void   GLUI_Tree::update_size()
 {
   int text_size = 0, delta_x = 0;
 
@@ -265,7 +265,7 @@ void   GLUI_Tree::update_size( void )
 
 /**************************** GLUI_Tree::draw_pressed() ***********/
 
-void   GLUI_Tree::draw_pressed( void )
+void   GLUI_Tree::draw_pressed()
 {
   int left, right, top, bottom;
 

--- a/include/GL/glui.h
+++ b/include/GL/glui.h
@@ -624,7 +624,7 @@ class GLUIAPI GLUI_Main : public GLUI_Node
     friend void glui_visibility_func(int state);
     friend void glui_motion_func(int x, int y);
     friend void glui_entry_func(int state);
-    friend void glui_display_func( void );
+    friend void glui_display_func();
     friend void glui_idle_func();
 
     friend void glui_parent_window_reshape_func( int w, int h );
@@ -662,7 +662,7 @@ protected:
     GLUI_Control  *find_prev_control( GLUI_Control *control );
     void           create_standalone_window( const char *name, int x=-1, int y=-1 );
     void           create_subwindow( int parent,int window_alignment );
-    void           setup_default_glut_callbacks( void );
+    void           setup_default_glut_callbacks();
 
     void           mouse(int button, int state, int x, int y);
     void           keyboard(unsigned char key, int x, int y);
@@ -672,7 +672,7 @@ protected:
     void           visibility(int state);
     void           motion(int x, int y);
     void           entry(int state);
-    void           display( void );
+    void           display();
     void           idle();
     int            needs_idle();
 
@@ -689,7 +689,7 @@ protected:
 
     /********** Constructors and Destructors ***********/
 
-    GLUI_Main( void );
+    GLUI_Main();
 
 public:
     GLUI_StdBitmaps  std_bitmaps;
@@ -703,7 +703,7 @@ public:
     void         adjust_glut_xy( int &x, int &y ) { y = h-y; }
     void         activate_control( GLUI_Control *control, int how );
     void         align_controls( GLUI_Control *control );
-    void         deactivate_current_control( void );
+    void         deactivate_current_control();
     
     /** Draw a 3D-look pushed-out box around this rectangle */
     void         draw_raised_box( int x, int y, int w, int h );
@@ -736,7 +736,7 @@ public:
     void         check_subwindow_position();
     void         set_ortho_projection();
     void         set_viewport();
-    int          get_glut_window_id( void ) { return glut_window_id; } /* JVK */
+    int          get_glut_window_id() { return glut_window_id; } /* JVK */
 };
 
 /************************************************************/
@@ -818,10 +818,10 @@ public:
     virtual void   set_ptr_val( void *new_ptr )       { ptr_val = new_ptr; output_live(true); }
     virtual void   set_float_array_val( float *array_ptr );
 
-    virtual float  get_float_val( void )              { return float_val; }
-    virtual int    get_int_val( void )                { return int_val; }
+    virtual float  get_float_val()              { return float_val; }
+    virtual int    get_int_val()                { return int_val; }
     virtual void   get_float_array_val( float *array_ptr );
-    virtual int    get_id( void ) const { return user_id; }
+    virtual int    get_id() const { return user_id; }
     virtual void   set_id( int id ) { user_id=id; }
 
     virtual int mouse_down_handler( int local_x, int local_y )                 { return false; }
@@ -830,21 +830,21 @@ public:
     virtual int key_handler( unsigned char key, int modifiers )                { return false; }
     virtual int special_handler( int key,int modifiers )                       { return false; }
 
-    virtual void update_size( void )     { }
-    virtual void idle( void )            { }
+    virtual void update_size()     { }
+    virtual void idle()            { }
     virtual int  mouse_over( int state, int x, int y ) { return false; }
 
-    virtual void enable( void ); 
-    virtual void disable( void );
+    virtual void enable(); 
+    virtual void disable();
     virtual void activate( int how )     { active = true; }
-    virtual void deactivate( void )     { active = false; }
+    virtual void deactivate()     { active = false; }
 
     /** Hide (shrink into a rollout) and unhide (expose from a rollout) */
     void         hide_internal( int recurse );
     void         unhide_internal( int recurse );
 
     /** Return true if it currently makes sense to draw this class. */
-    int          can_draw( void ) { return (glui != NULL && hidden == false); }
+    int          can_draw() { return (glui != NULL && hidden == false); }
 
     /** Redraw this control.
        In single-buffering mode (drawing to GL_FRONT), this is just 
@@ -857,18 +857,18 @@ public:
     /** Redraw everybody in our window. */
     void         redraw_window();
 
-    virtual void align( void );
+    virtual void align();
     void         pack( int x, int y );    /* Recalculate positions and offsets */
     void         pack_old( int x, int y );    
     void         draw_recursive( int x, int y );
-    int          set_to_glut_window( void );
+    int          set_to_glut_window();
     void         restore_window( int orig );
-    void         translate_and_draw_front( void );
-    void         translate_to_origin( void ) 
+    void         translate_and_draw_front();
+    void         translate_to_origin() 
     {glTranslatef((float)x_abs+.5,(float)y_abs+.5,0.0);}
     virtual void draw( int x, int y )=0;
     void         set_font( void *new_font );
-    void        *get_font( void );
+    void        *get_font();
     int          string_width( const char *text );
     int          string_width( const GLUI_String &str ) 
     { return string_width(str.c_str()); }
@@ -886,20 +886,20 @@ public:
     { draw_string(s.c_str()); }
     void         draw_char( char c );
     void         draw_active_box( int x_min, int x_max, int y_min, int y_max );
-    void         set_to_bkgd_color( void );
+    void         set_to_bkgd_color();
 
     void         set_w( int new_w );
     void         set_h( int new_w );
     void         set_alignment( int new_align );
     void         sync_live( int recurse, int draw );  /* Reads live variable */
-    void         init_live( void );
+    void         init_live();
     void         output_live( int update_main_gfx );        /** Writes live variable **/
     virtual void set_text( const char *t )   {}
-    void         execute_callback( void );
+    void         execute_callback();
     void         get_this_column_dims( int *col_x, int *col_y, 
                                        int *col_w, int *col_h, 
                                        int *col_x_off, int *col_y_off );
-    virtual bool needs_idle( void ) const;
+    virtual bool needs_idle() const;
     virtual bool wants_tabs() const      { return false; }
 
     GLUI_Control() 
@@ -964,10 +964,10 @@ public:
     int  key_handler( unsigned char key,int modifiers );
 
     void draw( int x, int y );
-    void draw_pressed( void );
+    void draw_pressed();
     void draw_text( int sunken );
 
-    void update_size( void );
+    void update_size();
 
 /**
  Create a new button.
@@ -979,7 +979,7 @@ public:
 */
     GLUI_Button( GLUI_Node *parent, const char *name, 
                  int id=-1, GLUI_CB cb=GLUI_CB() );
-    GLUI_Button( void ) { common_init(); };
+    GLUI_Button() { common_init(); };
 
 protected:
     void common_init() {
@@ -1014,12 +1014,12 @@ public:
     int  mouse_held_down_handler( int local_x, int local_y, bool inside );
     int  key_handler( unsigned char key,int modifiers );
 
-    void update_size( void );
+    void update_size();
 
     void draw( int x, int y );
 
-    void draw_active_area( void );
-    void draw_empty_box( void );
+    void draw_active_area();
+    void draw_empty_box();
     void set_int_val( int new_val );
 
 /**
@@ -1034,7 +1034,7 @@ public:
 */
     GLUI_Checkbox(GLUI_Node *parent, const char *name, int *value_ptr=NULL,
                   int id=-1, GLUI_CB callback=GLUI_CB());
-    GLUI_Checkbox( void ) { common_init(); }
+    GLUI_Checkbox() { common_init(); }
 
 protected:
     void common_init() {
@@ -1071,7 +1071,7 @@ public:
   @param draw_bar If true, draw a visible bar between new and old controls.
 */
     GLUI_Column( GLUI_Node *parent, int draw_bar = true );
-    GLUI_Column( void ) { common_init(); }
+    GLUI_Column() { common_init(); }
 
 protected:
     void common_init() {
@@ -1113,10 +1113,10 @@ public:
     void set_name( const char *text );
     void set_type( int new_type );
 
-    void update_size( void );
+    void update_size();
 
 protected:
-    void common_init( void ) {
+    void common_init() {
         w            = 300;
         h            = GLUI_DEFAULT_CONTROL_HEIGHT + 7;
         int_val      = GLUI_PANEL_EMBOSSED;
@@ -1218,22 +1218,22 @@ public:
 */
     GLUI_Rollout( GLUI_Node *parent, const char *name, int open=true, 
                   int type=GLUI_PANEL_EMBOSSED );
-    GLUI_Rollout( void ) { common_init(); }
+    GLUI_Rollout() { common_init(); }
     
     
     bool        currently_inside, initially_inside;
     GLUI_Button  button;
 
     void draw( int x, int y );
-    void draw_pressed( void );
+    void draw_pressed();
     int mouse_down_handler( int local_x, int local_y );
     int mouse_up_handler( int local_x, int local_y, bool inside );
     int  mouse_held_down_handler( int local_x, int local_y, bool inside );
         
-    void  open( void ); 
-    void  close( void );
+    void  open(); 
+    void  close();
 
-    void update_size( void );
+    void update_size();
 
 protected:
     void common_init() {
@@ -1286,16 +1286,16 @@ public:
     GLUI_TreePanel *panel; 
 
     void draw( int x, int y );
-    void draw_pressed( void );
+    void draw_pressed();
     int mouse_down_handler( int local_x, int local_y );
     int mouse_up_handler( int local_x, int local_y, bool inside );
     int  mouse_held_down_handler( int local_x, int local_y, bool inside );
     void set_column(GLUI_Column *c) { column = c; }
-    void  open( void ); 
-    void  close( void );
+    void  open(); 
+    void  close();
 
     /*   void set_name( const char *text )   { panel.set_name( text ); }; */
-    void update_size( void );
+    void update_size();
     void set_id(int i) { id = i; }
     void set_level(int l) { level = l; }
     void set_format(int f) { format = f; }
@@ -1396,16 +1396,16 @@ public:
     void            descendBranch(GLUI_Panel *root = NULL);
     /* Resets curr_root and curr branch to TreePanel and lastChild */
     void            resetToRoot(GLUI_Panel *new_root = NULL);
-    void            next( void );
-    void            refresh( void );
-    void            expand_all( void );
-    void            collapse_all( void );
-    void            update_all( void );
+    void            next();
+    void            refresh();
+    void            expand_all();
+    void            collapse_all();
+    void            update_all();
     void            initNode(GLUI_Tree *temp);
     void            formatNode(GLUI_Tree *temp);
 
 protected:
-    int uniqueID( void ) { next_id++; return next_id - 1; }
+    int uniqueID() { next_id++; return next_id - 1; }
     void common_init() 
     {
         GLUI_Panel();
@@ -1441,7 +1441,7 @@ public:
     void  add_column( int draw_bar = true );
     void  add_column_to_panel( GLUI_Panel *panel, int draw_bar = true );
 
-    void  add_separator( void );
+    void  add_separator();
     void  add_separator_to_panel( GLUI_Panel *panel );
 
     GLUI_RadioGroup 
@@ -1531,17 +1531,17 @@ public:
 
 /** Set the window where our widgets should be displayed. */
     void            set_main_gfx_window( int window_id );
-    int             get_glut_window_id( void ) { return glut_window_id; }
+    int             get_glut_window_id() { return glut_window_id; }
 
-    void            enable( void ) { main_panel->enable(); }
-    void            disable( void );
+    void            enable() { main_panel->enable(); }
+    void            disable();
 
-    void            sync_live( void );
+    void            sync_live();
 
-    void            close( void );
+    void            close();
 
-    void            show( void );
-    void            hide( void );
+    void            show();
+    void            hide();
 
     /***** GLUT callback setup functions *****/
     /*
@@ -1604,7 +1604,7 @@ public:
     int  special_handler( int key, int modifiers );
 
     void activate( int how );
-    void deactivate( void );
+    void deactivate();
 
     void draw( int x, int y );
 
@@ -1614,13 +1614,13 @@ public:
     int  substring_width( int start, int end );
     void clear_substring( int start, int end );
     int  find_insertion_pt( int x, int y );
-    int  update_substring_bounds( void );
-    void update_and_draw_text( void );
+    int  update_substring_bounds();
+    void update_and_draw_text();
     void draw_text( int x, int y );
-    void draw_insertion_pt( void );
-    void set_numeric_text( void );
-    void update_x_offsets( void );
-    void update_size( void );
+    void draw_insertion_pt();
+    void set_numeric_text();
+    void update_x_offsets();
+    void update_size();
 
     void set_float_limits( float low,float high,int limit_type=GLUI_LIMIT_CLAMP);
     void set_int_limits( int low, int high, int limit_type=GLUI_LIMIT_CLAMP );
@@ -1658,10 +1658,10 @@ public:
                    int text_type, void *live_var,
                    int id, GLUI_CB callback );
     // Deprecated constructor, only called internally
-    GLUI_EditText( void ) { common_init(); }
+    GLUI_EditText() { common_init(); }
 
 protected:
-    void common_init( void ) {
+    void common_init() {
         h                     = GLUI_EDITTEXT_HEIGHT;
         w                     = GLUI_EDITTEXT_WIDTH;
         title_x_offset        = 0;
@@ -1716,7 +1716,7 @@ public:
 public:
     int  key_handler( unsigned char key,int modifiers );
     int  special_handler(	int key,int modifiers );
-    void deactivate( void );
+    void deactivate();
 
     virtual const char *get_history( int command_number ) const
     { return hist_list[command_number - oldest_hist].c_str(); }
@@ -1727,14 +1727,14 @@ public:
     virtual void recall_history( int history_number );
     virtual void scroll_history( int direction );
     virtual void add_to_history( const char *text );
-    virtual void reset_history( void );
+    virtual void reset_history();
 
     void dump( FILE *out, const char *text );
 
 
     GLUI_CommandLine( GLUI_Node *parent, const char *name, void *live_var=NULL,
                       int id=-1, GLUI_CB callback=GLUI_CB() );
-    GLUI_CommandLine( void ) { common_init(); }
+    GLUI_CommandLine() { common_init(); }
 protected:
     void common_init() {
         hist_list.resize(HIST_SIZE);
@@ -1766,10 +1766,10 @@ public:
 
     GLUI_RadioGroup( GLUI_Node *parent, int *live_var=NULL,
                      int user_id=-1,GLUI_CB callback=GLUI_CB() );
-    GLUI_RadioGroup( void ) { common_init(); }
+    GLUI_RadioGroup() { common_init(); }
 
 protected:
-    void common_init( void ) {
+    void common_init() {
         x_off         = 0;
         y_off_top     = 0;
         y_off_bot     = 0;
@@ -1801,12 +1801,12 @@ public:
     int  mouse_held_down_handler( int local_x, int local_y, bool inside );
 
     void draw( int x, int y );
-    void update_size( void );
+    void update_size();
 
-    void draw_active_area( void );
-    void draw_checked( void );
-    void draw_unchecked( void );
-    void draw_O( void );
+    void draw_active_area();
+    void draw_checked();
+    void draw_unchecked();
+    void draw_O();
 
     GLUI_RadioButton( GLUI_RadioGroup *group, const char *name );
     GLUI_RadioGroup *group;
@@ -1836,7 +1836,7 @@ public:
     void draw( int x, int y );
 
     GLUI_Separator( GLUI_Node *parent );
-    GLUI_Separator( void ) { common_init(); }
+    GLUI_Separator() { common_init(); }
 
 protected:
     void common_init() {
@@ -1881,7 +1881,7 @@ public:
                   void *live_var,
                   int id=-1, GLUI_CB callback=GLUI_CB() );
     // Deprecated constructor
-    GLUI_Spinner( void ) { common_init(); }
+    GLUI_Spinner() { common_init(); }
 
     bool          currently_inside;
     int           state;
@@ -1903,29 +1903,29 @@ public:
     int  special_handler(   int key,int modifiers );
 
     void draw( int x, int y );
-    void draw_pressed( void );
-    void draw_unpressed( void );
+    void draw_pressed();
+    void draw_unpressed();
     void draw_text( int sunken );
 
-    void update_size( void );
+    void update_size();
 
     void set_float_limits( float low,float high,int limit_type=GLUI_LIMIT_CLAMP);
     void set_int_limits( int low, int high,int limit_type=GLUI_LIMIT_CLAMP);
     int  find_arrow( int local_x, int local_y );
     void do_drag( int x, int y );
-    void do_callbacks( void );
-    void do_click( void );
-    void idle( void );
-    bool needs_idle( void ) const;
+    void do_callbacks();
+    void do_click();
+    void idle();
+    bool needs_idle() const;
 
-    const char *get_text( void );
+    const char *get_text();
 
     void set_float_val( float new_val );
     void set_int_val( int new_val );
-    float  get_float_val( void );
-    int    get_int_val( void );
-    void increase_growth( void );
-    void reset_growth( void );
+    float  get_float_val();
+    int    get_int_val();
+    void increase_growth();
+    void reset_growth();
 
     void set_speed( float speed ) { user_speed = speed; }
 
@@ -1961,12 +1961,12 @@ class GLUIAPI GLUI_StaticText : public GLUI_Control
 public:
     void set_text( const char *text );
     void draw( int x, int y );
-    void draw_text( void );
-    void update_size( void );
-    void erase_text( void );
+    void draw_text();
+    void update_size();
+    void erase_text();
 
     GLUI_StaticText(GLUI_Node *parent, const char *name);
-    GLUI_StaticText( void ) { common_init(); }
+    GLUI_StaticText() { common_init(); }
 
 protected:
     void common_init() {
@@ -2017,10 +2017,10 @@ public:
     int  special_handler( int key,int modifiers );
   
     void activate( int how );
-    void deactivate( void );
+    void deactivate();
 
-    void enable( void );
-    void disable( void );
+    void enable();
+    void disable();
 
     void draw( int x, int y );
 
@@ -2031,22 +2031,22 @@ public:
     int  substring_width( int start, int end, int initial_width=0 );
     void clear_substring( int start, int end );
     int  find_insertion_pt( int x, int y );
-    int  update_substring_bounds( void );
-    void update_and_draw_text( void );
+    int  update_substring_bounds();
+    void update_and_draw_text();
     void draw_text( int x, int y );
-    void draw_insertion_pt( void );
-    void update_x_offsets( void );
-    void update_size( void );
+    void draw_insertion_pt();
+    void update_x_offsets();
+    void update_size();
 
     void set_text( const char *text );
-    const char *get_text( void )         { return text.c_str(); }
+    const char *get_text()         { return text.c_str(); }
 
     void dump( FILE *out, const char *text );
     void set_tab_w(int w) { tab_width = w; }
     void set_start_line(int l) { start_line = l; }
     static void scrollbar_callback(GLUI_Control*);
 
-    bool wants_tabs( void ) const { return true; }
+    bool wants_tabs() const { return true; }
 
 protected:
     void common_init()
@@ -2137,7 +2137,7 @@ public:
     int  special_handler( int key,int modifiers );
   
     void activate( int how );
-    void deactivate( void );
+    void deactivate();
 
     void draw( int x, int y );
 
@@ -2147,9 +2147,9 @@ public:
     int  find_word_break( int start, int direction );
     int  substring_width( const char *t, int start, int end );
     int  find_line( int x, int y );
-    void update_and_draw_text( void );
+    void update_and_draw_text();
     void draw_text( const char *t, int selected, int x, int y );
-    void update_size( void );
+    void update_size();
 
 
     int  add_item( int id, const char *text );
@@ -2271,25 +2271,25 @@ public:
     int  special_handler( int key,int modifiers );
   
     void draw( int x, int y );
-    void draw_pressed( void );
-    void draw_unpressed( void );
+    void draw_pressed();
+    void draw_unpressed();
     void draw_text( int sunken );
 
-    void update_size( void );
+    void update_size();
 
     void set_int_limits( int low, int high,int limit_type=GLUI_LIMIT_CLAMP);
     void set_float_limits( float low,float high,int limit_type=GLUI_LIMIT_CLAMP);
     int  find_arrow( int local_x, int local_y );
     void do_drag( int x, int y );
-    void do_callbacks( void );
-    void draw_scroll( void );
-    void do_click( void );
-    void idle( void );
-    bool needs_idle( void ) const;
+    void do_callbacks();
+    void draw_scroll();
+    void do_click();
+    void idle();
+    bool needs_idle() const;
     void set_int_val( int new_val );
     void set_float_val( float new_val );
-    void increase_growth( void );
-    void reset_growth( void );
+    void increase_growth();
+    void reset_growth();
 
     void set_speed( float speed ) { user_speed = speed; };
     void update_scroll_parameters();
@@ -2297,7 +2297,7 @@ public:
     { object_cb=cb; associated_object=obj; }
 
 protected:
-    void common_init ( void );
+    void common_init ();
     void common_construct(
         GLUI_Node *parent,
         const char *name, 
@@ -2343,7 +2343,7 @@ public:
     int  key_handler( unsigned char key,int modifiers );
     int  special_handler( int key,int modifiers );
 
-    void update_size( void );
+    void update_size();
     void draw( int x, int y );
     int  mouse_over( int state, int x, int y );
 
@@ -2353,7 +2353,7 @@ public:
     int  add_item( int id, const char *text );
     int  delete_item( const char *text );
     int  delete_item( int id );
-    int  sort_items( void );
+    int  sort_items();
 
     int  do_selection( int item );
 
@@ -2364,11 +2364,11 @@ public:
     GLUI_Listbox( GLUI_Node *parent,
                   const char *name, int *live_var=NULL,
                   int id=-1, GLUI_CB callback=GLUI_CB() );
-    GLUI_Listbox( void ) { common_init(); }
+    GLUI_Listbox() { common_init(); }
 
 protected:
     /** Change w and return true if we need to be widened to fit the current item. */
-    bool recalculate_item_width( void );
+    bool recalculate_item_width();
     void common_init() {
         glui_format_str( name, "Listbox: %p", this );
         w              = GLUI_EDITTEXT_WIDTH;
@@ -2398,16 +2398,16 @@ protected:
 class GLUIAPI GLUI_Mouse_Interaction : public GLUI_Control
 {
 public:
-    /*int  get_main_area_size( void ) { return MIN( h-18,  */
+    /*int  get_main_area_size() { return MIN( h-18,  */
     int            draw_active_area_only;
 
     int  mouse_down_handler( int local_x, int local_y );
     int  mouse_up_handler( int local_x, int local_y, bool inside );
     int  mouse_held_down_handler( int local_x, int local_y, bool inside );
     int  special_handler( int key, int modifiers );
-    void update_size( void );
+    void update_size();
     void draw( int x, int y );
-    void draw_active_area( void );
+    void draw_active_area();
 
     /***  The following methods (starting with "iaction_") need to
           be overloaded  ***/
@@ -2415,12 +2415,12 @@ public:
     virtual int  iaction_mouse_up_handler( int local_x, int local_y, bool inside )=0;
     virtual int  iaction_mouse_held_down_handler( int local_x, int local_y, bool inside )=0;
     virtual int  iaction_special_handler( int key, int modifiers )=0;
-    virtual void iaction_draw_active_area_persp( void )=0;
-    virtual void iaction_draw_active_area_ortho( void )=0;
+    virtual void iaction_draw_active_area_persp()=0;
+    virtual void iaction_draw_active_area_ortho()=0;
     virtual void iaction_dump( FILE *output )=0;
-    virtual void iaction_init( void ) = 0;
+    virtual void iaction_init() = 0;
   
-    GLUI_Mouse_Interaction( void ) {
+    GLUI_Mouse_Interaction() {
         glui_format_str( name, "Mouse_Interaction: %p", this );
         w              = GLUI_MOUSE_INTERACTION_WIDTH;
         h              = GLUI_MOUSE_INTERACTION_HEIGHT;
@@ -2453,28 +2453,28 @@ public:
     int  iaction_mouse_up_handler( int local_x, int local_y, bool inside );
     int  iaction_mouse_held_down_handler( int local_x, int local_y, bool inside );
     int  iaction_special_handler( int key, int modifiers );
-    void iaction_init( void ) { init_ball(); }
-    void iaction_draw_active_area_persp( void );
-    void iaction_draw_active_area_ortho( void );
+    void iaction_init() { init_ball(); }
+    void iaction_draw_active_area_persp();
+    void iaction_draw_active_area_ortho();
     void iaction_dump( FILE *output );
 
-    /*  void update_size( void ); */
+    /*  void update_size(); */
     /*  void draw( int x, int y ); */
     /*  int mouse_over( int state, int x, int y ); */
 
-    void setup_texture( void );
-    void setup_lights( void );
+    void setup_texture();
+    void setup_lights();
     void draw_ball( float radius );
 
-    void init_ball( void );
+    void init_ball();
 
-    void reset( void );
+    void reset();
 
-    bool needs_idle( void ) const;
-    void idle( void );
+    bool needs_idle() const;
+    void idle();
 
-    void copy_float_array_to_ball( void );
-    void copy_ball_to_float_array( void );
+    void copy_float_array_to_ball();
+    void copy_ball_to_float_array();
 
     void set_spin( float damp_factor );
 
@@ -2511,15 +2511,15 @@ public:
     int  iaction_mouse_up_handler( int local_x, int local_y, bool inside );
     int  iaction_mouse_held_down_handler( int local_x, int local_y, bool inside );
     int  iaction_special_handler( int key, int modifiers );
-    void iaction_init( void ) { }
-    void iaction_draw_active_area_persp( void );
-    void iaction_draw_active_area_ortho( void );
+    void iaction_init() { }
+    void iaction_draw_active_area_persp();
+    void iaction_draw_active_area_ortho();
     void iaction_dump( FILE *output );
 
     void set_speed( float s ) { scale_factor = s; }
 
-    void setup_texture( void );
-    void setup_lights( void );
+    void setup_texture();
+    void setup_lights();
     void draw_2d_arrow( int radius, int filled, int orientation ); 
     void draw_2d_x_arrows( int radius );
     void draw_2d_y_arrows( int radius );
@@ -2531,9 +2531,9 @@ public:
     /* Float array is either a single float (for single-axis controls),
        or two floats for X and Y (if an XY controller) */
 
-    float get_z( void ) {       return float_array_val[0];  }
-    float get_x( void ) {       return float_array_val[0];  }
-    float get_y( void ) {
+    float get_z() {       return float_array_val[0];  }
+    float get_x() {       return float_array_val[0];  }
+    float get_y() {
         if ( trans_type == GLUI_TRANSLATION_XY )    return float_array_val[1];
         else					return float_array_val[0];
     }
@@ -2546,7 +2546,7 @@ public:
     GLUI_Translation( GLUI_Node *parent, const char *name,
                       int trans_type, float *live_var=NULL,
                       int id=-1, GLUI_CB callback=GLUI_CB()	);
-    GLUI_Translation( void ) { common_init(); }
+    GLUI_Translation() { common_init(); }
 
 protected:
     void common_init() {
@@ -2575,7 +2575,7 @@ void _glutBitmapString( void *font, const char *s );
    glut callbacks.  
 */
 
-void glui_display_func( void );
+void glui_display_func();
 void glui_reshape_func( int w, int h );
 void glui_keyboard_func(unsigned char key, int x, int y);
 void glui_special_func(int key, int x, int y);

--- a/include/GL/glui.h
+++ b/include/GL/glui.h
@@ -10,8 +10,8 @@
 
   Copyright (c) 1998 Paul Rademacher
 
-  WWW:    https://github.com/libglui/glui
-  Issues: https://github.com/libglui/glui/issues
+  WWW:    http://sourceforge.net/projects/glui/
+  Forums: http://sourceforge.net/forum/?group_id=92496
 
   This software is provided 'as-is', without any express or implied 
   warranty. In no event will the authors be held liable for any damages 

--- a/include/GL/glui.h
+++ b/include/GL/glui.h
@@ -10,8 +10,8 @@
 
   Copyright (c) 1998 Paul Rademacher
 
-  WWW:    http://sourceforge.net/projects/glui/
-  Forums: http://sourceforge.net/forum/?group_id=92496
+  WWW:    https://github.com/libglui/glui
+  Issues: https://github.com/libglui/glui/issues
 
   This software is provided 'as-is', without any express or implied 
   warranty. In no event will the authors be held liable for any damages 
@@ -485,7 +485,7 @@ public:
 
     GLUI_Glut_Window   *find_glut_window( int window_id );
 
-    void           set_glutIdleFunc(void (*f)(void));
+    void           set_glutIdleFunc(void (*f)());
 
     /**************
     void (*glut_keyboard_CB)(unsigned char, int, int);
@@ -496,7 +496,7 @@ public:
     void (*glut_passive_motion_CB)(int,int);
     void (*glut_visibility_CB)(int);
     void (*glut_motion_CB)(int,int);
-    void (*glut_display_CB)(void);
+    void (*glut_display_CB)();
     void (*glut_entry_CB)(int);
     **********/
 
@@ -510,10 +510,10 @@ public:
     void set_glutSpecialFunc (void (*f)(int key, int x, int y));
     void set_glutMouseFunc   (void (*f)(int, int, int, int ));
 
-    void set_glutDisplayFunc(void (*f)(void)) {glutDisplayFunc(f);}
+    void set_glutDisplayFunc(void (*f)()) {glutDisplayFunc(f);}
     void set_glutTimerFunc(unsigned int millis, void (*f)(int value), int value)
     { ::glutTimerFunc(millis,f,value);}
-    void set_glutOverlayDisplayFunc(void(*f)(void)){glutOverlayDisplayFunc(f);}
+    void set_glutOverlayDisplayFunc(void(*f)()){glutOverlayDisplayFunc(f);}
     void set_glutSpaceballMotionFunc(Int3_CB f)  {glutSpaceballMotionFunc(f);}
     void set_glutSpaceballRotateFunc(Int3_CB f)  {glutSpaceballRotateFunc(f);}
     void set_glutSpaceballButtonFunc(Int2_CB f)  {glutSpaceballButtonFunc(f);}
@@ -538,11 +538,11 @@ public:
 
     float          get_version() { return GLUI_VERSION; }
 
-    void glui_setIdleFuncIfNecessary(void);
+    void glui_setIdleFuncIfNecessary();
 
 private:
     GLUI_Node     glut_windows;
-    void (*glut_idle_CB)(void);
+    void (*glut_idle_CB)();
 
     void          add_cb_to_glut_window(int window,int cb_type,void *cb);
 };
@@ -581,7 +581,7 @@ public:
     void (*glut_mouse_CB)(int,int,int,int);
     void (*glut_visibility_CB)(int);
     void (*glut_motion_CB)(int,int);
-    void (*glut_display_CB)(void);
+    void (*glut_display_CB)();
     void (*glut_entry_CB)(int);
 };
 
@@ -625,7 +625,7 @@ class GLUIAPI GLUI_Main : public GLUI_Node
     friend void glui_motion_func(int x, int y);
     friend void glui_entry_func(int state);
     friend void glui_display_func( void );
-    friend void glui_idle_func(void);
+    friend void glui_idle_func();
 
     friend void glui_parent_window_reshape_func( int w, int h );
     friend void glui_parent_window_keyboard_func( unsigned char, int, int );
@@ -673,8 +673,8 @@ protected:
     void           motion(int x, int y);
     void           entry(int state);
     void           display( void );
-    void           idle(void);
-    int            needs_idle(void);
+    void           idle();
+    int            needs_idle();
 
     void (*glut_mouse_CB)(int, int, int, int);
     void (*glut_keyboard_CB)(unsigned char, int, int);
@@ -852,10 +852,10 @@ public:
        In double-buffering mode (drawing to GL_BACK), this queues up 
           a redraw and returns false, since you shouldn't draw yet.
     */
-    void          redraw(void);
+    void          redraw();
     
     /** Redraw everybody in our window. */
-    void         redraw_window(void);
+    void         redraw_window();
 
     virtual void align( void );
     void         pack( int x, int y );    /* Recalculate positions and offsets */
@@ -902,7 +902,7 @@ public:
     virtual bool needs_idle( void ) const;
     virtual bool wants_tabs() const      { return false; }
 
-    GLUI_Control(void) 
+    GLUI_Control() 
     {
         x_off          = GLUI_XOFF;
         y_off_top      = GLUI_YOFF;
@@ -982,7 +982,7 @@ public:
     GLUI_Button( void ) { common_init(); };
 
 protected:
-    void common_init(void) {
+    void common_init() {
         glui_format_str(name, "Button: %p", this );
         h            = GLUI_BUTTON_SIZE;
         w            = 100;
@@ -1037,7 +1037,7 @@ public:
     GLUI_Checkbox( void ) { common_init(); }
 
 protected:
-    void common_init(void) {
+    void common_init() {
         glui_format_str( name, "Checkbox: %p", this );
         w              = 100;
         h              = GLUI_CHECKBOX_SIZE;
@@ -1545,7 +1545,7 @@ public:
 
     /***** GLUT callback setup functions *****/
     /*
-      void set_glutDisplayFunc(void (*f)(void));
+      void set_glutDisplayFunc(void (*f)());
       void set_glutReshapeFunc(void (*f)(int width, int height));
       void set_glutKeyboardFunc(void (*f)(unsigned char key, int x, int y));
       void set_glutSpecialFunc(void (*f)(int key, int x, int y));
@@ -2480,7 +2480,7 @@ public:
 
     GLUI_Rotation( GLUI_Node *parent, const char *name, float *live_var=NULL,
                    int id=-1, GLUI_CB callback=GLUI_CB() );
-    GLUI_Rotation(void) { common_init(); }
+    GLUI_Rotation() { common_init(); }
 
 protected:
     void common_init();
@@ -2584,7 +2584,7 @@ void glui_motion_func(int x, int y);
 void glui_passive_motion_func(int x, int y);
 void glui_entry_func(int state);
 void glui_visibility_func(int state);
-void glui_idle_func(void);
+void glui_idle_func();
 
 void glui_parent_window_reshape_func( int w, int h );
 void glui_parent_window_keyboard_func(unsigned char key, int x, int y);


### PR DESCRIPTION
For slightly modernising the GLUI codebase, omit `void` for parameterless functions and methods.