### PR TITLE
Adjust Travis-CI build status badge for libglui/glui repo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 https://github.com/libglui/glui
 
-[![Build Status](https://travis-ci.org/nigels-com/glui.svg?branch=master)](https://travis-ci.org/nigels-com/glui)
+[![Build Status](https://travis-ci.org/libglui/glui.svg?branch=master)](https://travis-ci.org/libglui/glui)
 
 This distribution contains the latest community-maintained fork of the
 GLUI Library, now under the ZLIB license.  It is based on the GLUI


### PR DESCRIPTION
I need to fiddle a bit for Travis and libglui/glui to be happy talking to each other.  Looks good to go now.