### PR TITLE
Resolve clang++ warnings concerning casting function pointers

### DIFF
--- a/glui.cpp
+++ b/glui.cpp
@@ -1653,7 +1653,7 @@ void  GLUI_Master_Object::reshape()
 void GLUI_Master_Object::set_glutReshapeFunc(void (*f)(int width, int height))
 {
   glutReshapeFunc( GLUI_Main::reshape_func );
-  add_cb_to_glut_window( glutGetWindow(), GLUI_GLUT_RESHAPE, (void*) f);
+  add_cb_to_glut_window( glutGetWindow(), GLUI_GLUT_RESHAPE, reinterpret_cast<void(*)()>(f));
 }
 
 
@@ -1663,7 +1663,7 @@ void GLUI_Master_Object::set_glutKeyboardFunc(void (*f)(unsigned char key,
 							int x, int y))
 {
   glutKeyboardFunc( GLUI_Main::keyboard_func );
-  add_cb_to_glut_window( glutGetWindow(), GLUI_GLUT_KEYBOARD, (void*) f);
+  add_cb_to_glut_window( glutGetWindow(), GLUI_GLUT_KEYBOARD, reinterpret_cast<void(*)()>(f));
 }
 
 
@@ -1673,7 +1673,7 @@ void GLUI_Master_Object::set_glutSpecialFunc(void (*f)(int key,
 						       int x, int y))
 {
   glutSpecialFunc( GLUI_Main::special_func );
-  add_cb_to_glut_window( glutGetWindow(), GLUI_GLUT_SPECIAL, (void*) f);
+  add_cb_to_glut_window( glutGetWindow(), GLUI_GLUT_SPECIAL, reinterpret_cast<void(*)()>(f));
 }
 
 
@@ -1683,7 +1683,7 @@ void GLUI_Master_Object::set_glutMouseFunc(void (*f)(int button, int state,
 						     int x, int y))
 {
   glutMouseFunc( GLUI_Main::mouse_func );
-  add_cb_to_glut_window( glutGetWindow(), GLUI_GLUT_MOUSE, (void*) f);
+  add_cb_to_glut_window( glutGetWindow(), GLUI_GLUT_MOUSE, reinterpret_cast<void(*)()>(f));
 }
 
 
@@ -1843,7 +1843,7 @@ GLUI_Glut_Window  *GLUI_Master_Object::find_glut_window( int window_id )
 /******************** GLUI_Master_Object::add_cb_to_glut_window() **********/
 
 void     GLUI_Master_Object::add_cb_to_glut_window(int window_id,
-						   int cb_type,void *cb)
+						   int cb_type, void(*cb)())
 {
   GLUI_Glut_Window *window;
 

--- a/include/GL/glui.h
+++ b/include/GL/glui.h
@@ -543,7 +543,7 @@ private:
     GLUI_Node     glut_windows;
     void (*glut_idle_CB)();
 
-    void          add_cb_to_glut_window(int window,int cb_type,void *cb);
+    void          add_cb_to_glut_window(int window,int cb_type,void(*cb)());
 };
 
 /**

--- a/makefile
+++ b/makefile
@@ -16,6 +16,11 @@ CXX      ?= g++
 CPPFLAGS += $(OPTS) -Wall -pedantic
 endif
 
+ifeq ($(UNAME), Darwin)
+CXX      ?= g++
+CPPFLAGS += $(OPTS) -Wall -pedantic
+endif
+
 #######################################
 
 CPPFLAGS += -I./ -I./include


### PR DESCRIPTION
Apparently casting to parameterless function pointer is less _undefined_ than casting to generic void pointer.