### PR TITLE
Move GLUT header dependency from glui.h to internals

### DIFF
--- a/example/example1.cpp
+++ b/example/example1.cpp
@@ -14,6 +14,12 @@
 #include <string.h>
 #include <GL/glui.h>
 
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
+#include <GL/glut.h>
+#endif
+
 /** These are the live variables passed into GLUI ***/
 int   wireframe = 0;
 int   segments = 8;

--- a/example/example2.cpp
+++ b/example/example2.cpp
@@ -13,6 +13,12 @@
 #include <string.h>
 #include <GL/glui.h>
 
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
+#include <GL/glut.h>
+#endif
+
 float xy_aspect;
 int   last_x, last_y;
 float rotationX = 0.0, rotationY = 0.0;

--- a/example/example3.cpp
+++ b/example/example3.cpp
@@ -14,6 +14,12 @@
 #include <string.h>
 #include <GL/glui.h>
 
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
+#include <GL/glut.h>
+#endif
+
 float xy_aspect;
 int   last_x, last_y;
 float rotationX = 0.0, rotationY = 0.0;

--- a/example/example4.cpp
+++ b/example/example4.cpp
@@ -13,6 +13,12 @@
 #include <string.h>
 #include <GL/glui.h>
 
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
+#include <GL/glut.h>
+#endif
+
 float xy_aspect;
 int   last_x, last_y;
 float rotationX = 0.0, rotationY = 0.0;

--- a/example/example5.cpp
+++ b/example/example5.cpp
@@ -14,6 +14,12 @@
 #include <string.h>
 #include <GL/glui.h>
 
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
+#include <GL/glut.h>
+#endif
+
 float xy_aspect;
 int   last_x, last_y;
 float rotationX = 0.0, rotationY = 0.0;

--- a/example/example6.cpp
+++ b/example/example6.cpp
@@ -14,6 +14,12 @@
 #include <string.h>
 #include <GL/glui.h>
 
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
+#include <GL/glut.h>
+#endif
+
 /** These are the live variables passed into GLUI ***/
 int main_window;
 int num_display  = 0;

--- a/glui.cpp
+++ b/glui.cpp
@@ -1686,6 +1686,19 @@ void GLUI_Master_Object::set_glutMouseFunc(void (*f)(int button, int state,
   add_cb_to_glut_window( glutGetWindow(), GLUI_GLUT_MOUSE, reinterpret_cast<void(*)()>(f));
 }
 
+void GLUI_Master_Object::set_glutDisplayFunc(void (*f)(void)) {glutDisplayFunc(f);}
+void GLUI_Master_Object::set_glutTimerFunc(unsigned int millis, void (*f)(int value), int value)
+{ ::glutTimerFunc(millis,f,value);}
+void GLUI_Master_Object::set_glutOverlayDisplayFunc(void(*f)(void)){glutOverlayDisplayFunc(f);}
+void GLUI_Master_Object::set_glutSpaceballMotionFunc(Int3_CB f)  {glutSpaceballMotionFunc(f);}
+void GLUI_Master_Object::set_glutSpaceballRotateFunc(Int3_CB f)  {glutSpaceballRotateFunc(f);}
+void GLUI_Master_Object::set_glutSpaceballButtonFunc(Int2_CB f)  {glutSpaceballButtonFunc(f);}
+void GLUI_Master_Object::set_glutTabletMotionFunc(Int2_CB f)        {glutTabletMotionFunc(f);}
+void GLUI_Master_Object::set_glutTabletButtonFunc(Int4_CB f)        {glutTabletButtonFunc(f);}
+void GLUI_Master_Object::set_glutMenuStatusFunc(Int3_CB f)            {glutMenuStatusFunc(f);}
+void GLUI_Master_Object::set_glutMenuStateFunc(Int1_CB f)              {glutMenuStateFunc(f);}
+void GLUI_Master_Object::set_glutButtonBoxFunc(Int2_CB f)              {glutButtonBoxFunc(f);}
+void GLUI_Master_Object::set_glutDialsFunc(Int2_CB f)                      {glutDialsFunc(f);}  
 
 /****************************** glui_parent_window_reshape_func() **********/
 /* This is the reshape callback for a window that contains subwindows      */

--- a/glui_internal.h
+++ b/glui_internal.h
@@ -22,6 +22,30 @@
 #include <cmath>
 #include <cassert>
 
+#if defined(GLUI_FREEGLUT)
+
+  // FreeGLUT does not yet work perfectly with GLUI
+  //  - use at your own risk.
+  
+  #include <GL/freeglut.h>
+
+#elif defined(GLUI_OPENGLUT)
+
+  // OpenGLUT does not yet work properly with GLUI
+  //  - use at your own risk.
+  
+  #include <GL/openglut.h>
+
+#else 
+
+  #ifdef __APPLE__
+  #include <GLUT/glut.h>
+  #else
+  #include <GL/glut.h>
+  #endif
+
+#endif
+
 #ifndef AND
 #define AND &&
 #define OR  ||

--- a/include/GL/glui.h
+++ b/include/GL/glui.h
@@ -34,34 +34,15 @@
 #ifndef GLUI_GLUI_H
 #define GLUI_GLUI_H
 
-// Having stdlib here first fixes some 'exit() redefined' errors on MSVC.NET
-// that come from old GLUT headers.
-#include <cstdlib>
-
-#if defined(GLUI_FREEGLUT)
-
-  // FreeGLUT does not yet work perfectly with GLUI
-  //  - use at your own risk.
-  
-  #include <GL/freeglut.h>
-
-#elif defined(GLUI_OPENGLUT)
-
-  // OpenGLUT does not yet work properly with GLUI
-  //  - use at your own risk.
-  
-  #include <GL/openglut.h>
-
-#else 
-
-  #ifdef __APPLE__
-  #include <GLUT/glut.h>
-  #else
-  #include <GL/glut.h>
-  #endif
-
+#ifdef __APPLE__
+#include <OpenGL/GL.h>
+#include <OpenGL/GLU.h>
+#else
+#include <GL/gl.h>
+#include <GL/glu.h>
 #endif
 
+#include <cstdlib>
 #include <cstdio>
 #include <cstring>
 
@@ -511,20 +492,19 @@ public:
     void set_glutSpecialFunc (void (*f)(int key, int x, int y));
     void set_glutMouseFunc   (void (*f)(int, int, int, int ));
 
-    void set_glutDisplayFunc(void (*f)()) {glutDisplayFunc(f);}
-    void set_glutTimerFunc(unsigned int millis, void (*f)(int value), int value)
-    { ::glutTimerFunc(millis,f,value);}
-    void set_glutOverlayDisplayFunc(void(*f)()){glutOverlayDisplayFunc(f);}
-    void set_glutSpaceballMotionFunc(Int3_CB f)  {glutSpaceballMotionFunc(f);}
-    void set_glutSpaceballRotateFunc(Int3_CB f)  {glutSpaceballRotateFunc(f);}
-    void set_glutSpaceballButtonFunc(Int2_CB f)  {glutSpaceballButtonFunc(f);}
-    void set_glutTabletMotionFunc(Int2_CB f)        {glutTabletMotionFunc(f);}
-    void set_glutTabletButtonFunc(Int4_CB f)        {glutTabletButtonFunc(f);}
+    void set_glutDisplayFunc(void (*f)(void));
+    void set_glutTimerFunc(unsigned int millis, void (*f)(int value), int value);
+    void set_glutOverlayDisplayFunc(void(*f)(void));
+    void set_glutSpaceballMotionFunc(Int3_CB f);
+    void set_glutSpaceballRotateFunc(Int3_CB f);
+    void set_glutSpaceballButtonFunc(Int2_CB f);
+    void set_glutTabletMotionFunc(Int2_CB f);
+    void set_glutTabletButtonFunc(Int4_CB f);
     /*    void set_glutWindowStatusFunc(Int1_CB f)        {glutWindowStatusFunc(f);} */
-    void set_glutMenuStatusFunc(Int3_CB f)            {glutMenuStatusFunc(f);}
-    void set_glutMenuStateFunc(Int1_CB f)              {glutMenuStateFunc(f);}
-    void set_glutButtonBoxFunc(Int2_CB f)              {glutButtonBoxFunc(f);}
-    void set_glutDialsFunc(Int2_CB f)                      {glutDialsFunc(f);}  
+    void set_glutMenuStatusFunc(Int3_CB f);
+    void set_glutMenuStateFunc(Int1_CB f);
+    void set_glutButtonBoxFunc(Int2_CB f);
+    void set_glutDialsFunc(Int2_CB f);  
   
 
     GLUI          *create_glui( const char *name, long flags=0, int x=-1, int y=-1 ); 


### PR DESCRIPTION
Some recent discussion and proposals to abstract from GLUT.

This PR moves the compile-time dependency to the internals of GLUI, and out of `glui.h`