### PR TITLE
std::function for GLUI callbacks

### DIFF
--- a/example/example2.cpp
+++ b/example/example2.cpp
@@ -30,39 +30,12 @@ int   wireframe = 0;
 int   obj = 0;
 int   segments = 8;
 
-// Using a std::string as a live variable is safe.
 std::string text = "Hello World!";
-
-// Using a char buffer as a live var is also possible, but it is dangerous 
-// because GLUI doesn't know how big your buffer is.  
-// But still, it works as long as text doesn't happen to overflow.
-//char  text[200] = {"Hello World!"};
 
 GLUI_Checkbox   *checkbox;
 GLUI_Spinner    *spinner;
 GLUI_RadioGroup *radio;
 GLUI_EditText   *edittext;
-
-/**************************************** control_cb() *******************/
-/* GLUI control callback                                                 */
-
-void control_cb( int control )
-{
-  /********************************************************************
-    Here we'll print the user id of the control that generated the
-    callback, and we'll also explicitly get the values of each control.
-    Note that we really didn't have to explicitly get the values, since
-    they are already all contained within the live variables:
-    'wireframe',  'segments',  'obj',  and 'text'  
-    ********************************************************************/
-
-  printf( "callback: %d\n", control );
-  printf( "             checkbox: %d\n", checkbox->get_int_val() );
-  printf( "              spinner: %d\n", spinner->get_int_val() );
-  printf( "          radio group: %d\n", radio->get_int_val() );
-  printf( "                 text: %s\n", edittext->get_text().c_str() );
-  
-}
 
 /**************************************** myGlutKeyboard() **********/
 
@@ -106,7 +79,6 @@ void myGlutMouse(int button, int button_state, int x, int y )
     last_y = y;
   }
 }
-
 
 /***************************************** myGlutMotion() **********/
 
@@ -240,16 +212,16 @@ int main(int argc, char* argv[])
 								 x, and y */
   new GLUI_StaticText( glui, "GLUI Example 2" );
   new GLUI_Separator( glui );
-  checkbox = new GLUI_Checkbox( glui, "Wireframe", &wireframe, 1, control_cb );
-  spinner  = new GLUI_Spinner( glui, "Segments:", &segments, 2, control_cb );
+  checkbox = new GLUI_Checkbox( glui, "Wireframe", &wireframe, [&]() { printf("Wireframe: %d\n", wireframe); });
+  spinner  = new GLUI_Spinner( glui, "Segments:",  &segments,  [&]() { printf("Segments: %d\n", segments); });
   spinner->set_int_limits( 3, 60 );
-  edittext = new GLUI_EditText( glui, "Text:", text, 3, control_cb );
+  edittext = new GLUI_EditText( glui, "Text:", text, [&]() { printf("Text: %s\n", text.c_str()); });
   GLUI_Panel *obj_panel = new GLUI_Panel( glui, "Object Type" );
-  radio = new GLUI_RadioGroup( obj_panel,&obj,4,control_cb );
+  radio = new GLUI_RadioGroup( obj_panel,&obj, [&]() { printf("Object: %d\n", obj); });
   new GLUI_RadioButton( radio, "Sphere" );
   new GLUI_RadioButton( radio, "Torus" );
   new GLUI_RadioButton( radio, "Teapot" );
-  new GLUI_Button( glui, "Quit", 0,(GLUI_Update_CB)exit );
+  new GLUI_Button( glui, "Quit", []() { printf("Exit\n"); exit(0); } );
  
   glui->set_main_gfx_window( main_window );
 

--- a/example/example4.cpp
+++ b/example/example4.cpp
@@ -44,12 +44,6 @@ GLUI_Spinner    *spinner, *light0_spinner, *light1_spinner;
 GLUI_RadioGroup *radio;
 GLUI_Panel      *obj_panel;
 
-/********** User IDs for callbacks ********/
-#define LIGHT0_ENABLED_ID    200
-#define LIGHT1_ENABLED_ID    201
-#define LIGHT0_INTENSITY_ID  250
-#define LIGHT1_INTENSITY_ID  251
-
 /********** Miscellaneous global variables **********/
 
 GLfloat light0_ambient[] =  {0.1f, 0.1f, 0.3f, 1.0f};
@@ -59,53 +53,6 @@ GLfloat light0_position[] = {.5f, .5f, 1.0f, 0.0f};
 GLfloat light1_ambient[] =  {0.1f, 0.1f, 0.3f, 1.0f};
 GLfloat light1_diffuse[] =  {.9f, .6f, 0.0f, 1.0f};
 GLfloat light1_position[] = {-1.0f, -1.0f, 1.0f, 0.0f};
-
-/**************************************** control_cb() *******************/
-/* GLUI control callback                                                 */
-
-void control_cb( int control )
-{
-  if ( control == LIGHT0_ENABLED_ID ) {
-    if ( light0_enabled ) {
-      glEnable( GL_LIGHT0 );
-      light0_spinner->enable();
-    }
-    else {
-      glDisable( GL_LIGHT0 ); 
-      light0_spinner->disable();
-    }
-  }
-  else if ( control == LIGHT1_ENABLED_ID ) {
-    if ( light1_enabled ) {
-      glEnable( GL_LIGHT1 );
-      light1_spinner->enable();
-    }
-    else {
-      glDisable( GL_LIGHT1 ); 
-      light1_spinner->disable();
-    }
-  }
-  else if ( control == LIGHT0_INTENSITY_ID ) {
-    float v[] = { light0_diffuse[0],  light0_diffuse[1],
-		  light0_diffuse[2],  light0_diffuse[3] };
-    
-    v[0] *= light0_intensity;
-    v[1] *= light0_intensity;
-    v[2] *= light0_intensity;
-
-    glLightfv(GL_LIGHT0, GL_DIFFUSE, v );
-  }
-  else if ( control == LIGHT1_INTENSITY_ID ) {
-    float v[] = { light1_diffuse[0],  light1_diffuse[1],
-		  light1_diffuse[2],  light1_diffuse[3] };
-    
-    v[0] *= light1_intensity;
-    v[1] *= light1_intensity;
-    v[2] *= light1_intensity;
-
-    glLightfv(GL_LIGHT1, GL_DIFFUSE, v );
-  }
-}
 
 /**************************************** myGlutKeyboard() **********/
 
@@ -301,7 +248,7 @@ int main(int argc, char* argv[])
   /***** Control for object params *****/
 
   checkbox = 
-    new GLUI_Checkbox( obj_panel, "Wireframe", &wireframe, 1, control_cb );
+    new GLUI_Checkbox( obj_panel, "Wireframe", &wireframe);
   spinner  = new GLUI_Spinner( obj_panel, "Segments:", &segments);
   spinner->set_int_limits( 3, 60 );
   spinner->set_alignment( GLUI_ALIGN_RIGHT );
@@ -326,27 +273,70 @@ int main(int argc, char* argv[])
   GLUI_Panel *light0 = new GLUI_Panel( panel1, "Light 1" );
   GLUI_Panel *light1 = new GLUI_Panel( panel1, "Light 2" );
 
-  new GLUI_Checkbox( light0, "Enabled", &light0_enabled,
-                     LIGHT0_ENABLED_ID, control_cb );
+  new GLUI_Checkbox( light0, "Enabled", &light0_enabled, [&]() 
+    { 
+      if (light0_enabled)
+      {
+        glEnable( GL_LIGHT0 );
+        light0_spinner->enable();
+      }
+      else
+      {
+        glDisable( GL_LIGHT0 ); 
+        light0_spinner->disable();
+      }
+    });
+
   light0_spinner = 
-    new GLUI_Spinner( light0, "Intensity:", 
-                      &light0_intensity, LIGHT0_INTENSITY_ID,
-                      control_cb );
+    new GLUI_Spinner( light0, "Intensity:",
+                      &light0_intensity, [&]()
+      {
+        float v[] = { light0_diffuse[0],  light0_diffuse[1],
+          light0_diffuse[2],  light0_diffuse[3] };
+        
+        v[0] *= light0_intensity;
+        v[1] *= light0_intensity;
+        v[2] *= light0_intensity;
+
+        glLightfv(GL_LIGHT0, GL_DIFFUSE, v);
+      });
   light0_spinner->set_float_limits( 0.0, 1.0 );
 
-  new GLUI_Checkbox( light1, "Enabled", &light1_enabled,
-                     LIGHT1_ENABLED_ID, control_cb );
+  new GLUI_Checkbox( light1, "Enabled", &light1_enabled, [&]() 
+    { 
+      if (light1_enabled)
+      {
+        glEnable( GL_LIGHT1 );
+        light1_spinner->enable();
+      }
+      else
+      {
+        glDisable( GL_LIGHT1 ); 
+        light1_spinner->disable();
+      }
+    });
+
   light1_spinner = 
-    new GLUI_Spinner( light1, "Intensity:",
-                      &light1_intensity, LIGHT1_INTENSITY_ID,
-                      control_cb );
+    new GLUI_Spinner( light1, "Intensity:", 
+                      &light1_intensity, [&]()
+      {
+        float v[] = { light1_diffuse[0],  light1_diffuse[1],
+          light1_diffuse[2],  light1_diffuse[3] };
+        
+        v[0] *= light1_intensity;
+        v[1] *= light1_intensity;
+        v[2] *= light1_intensity;
+
+        glLightfv(GL_LIGHT1, GL_DIFFUSE, v);
+      });
+
   light1_spinner->set_float_limits( 0.0, 1.0 );
   light1_spinner->disable();   /* Disable this light initially */
 
   
   /****** A 'quit' button *****/
 
-  new GLUI_Button( glui, "Quit", 0,(GLUI_Update_CB)exit );
+  new GLUI_Button( glui, "Quit", []() { exit(0); });
 
 
   /**** Link windows to GLUI ******/

--- a/example/example5.cpp
+++ b/example/example5.cpp
@@ -52,17 +52,6 @@ GLUI_Spinner    *light0_spinner, *light1_spinner;
 GLUI_RadioGroup *radio;
 GLUI_Panel      *obj_panel;
 
-/********** User IDs for callbacks ********/
-#define LIGHT0_ENABLED_ID    200
-#define LIGHT1_ENABLED_ID    201
-#define LIGHT0_INTENSITY_ID  250
-#define LIGHT1_INTENSITY_ID  260
-#define ENABLE_ID            300
-#define DISABLE_ID           301
-#define SHOW_ID              302
-#define HIDE_ID              303
-
-
 /********** Miscellaneous global variables **********/
 
 GLfloat light0_ambient[] =  {0.1f, 0.1f, 0.3f, 1.0f};
@@ -74,71 +63,6 @@ GLfloat light1_diffuse[] =  {.9f, .6f, 0.0f, 1.0f};
 GLfloat light1_position[] = {-1.0f, -1.0f, 1.0f, 0.0f};
 
 GLfloat lights_rotation[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1 };
-
-/**************************************** control_cb() *******************/
-/* GLUI control callback                                                 */
-
-void control_cb( int control )
-{
-  if ( control == LIGHT0_ENABLED_ID ) {
-    if ( light0_enabled ) {
-      glEnable( GL_LIGHT0 );
-      light0_spinner->enable();
-    }
-    else {
-      glDisable( GL_LIGHT0 ); 
-      light0_spinner->disable();
-    }
-  }
-  else if ( control == LIGHT1_ENABLED_ID ) {
-    if ( light1_enabled ) {
-      glEnable( GL_LIGHT1 );
-      light1_spinner->enable();
-    }
-    else {
-      glDisable( GL_LIGHT1 ); 
-      light1_spinner->disable();
-    }
-  }
-  else if ( control == LIGHT0_INTENSITY_ID ) {
-    float v[] = { 
-      light0_diffuse[0],  light0_diffuse[1],
-      light0_diffuse[2],  light0_diffuse[3] };
-    
-    v[0] *= light0_intensity;
-    v[1] *= light0_intensity;
-    v[2] *= light0_intensity;
-
-    glLightfv(GL_LIGHT0, GL_DIFFUSE, v );
-  }
-  else if ( control == LIGHT1_INTENSITY_ID ) {
-    float v[] = { 
-      light1_diffuse[0],  light1_diffuse[1],
-      light1_diffuse[2],  light1_diffuse[3] };
-    
-    v[0] *= light1_intensity;
-    v[1] *= light1_intensity;
-    v[2] *= light1_intensity;
-
-    glLightfv(GL_LIGHT1, GL_DIFFUSE, v );
-  }
-  else if ( control == ENABLE_ID )
-  {
-    glui2->enable();
-  }
-  else if ( control == DISABLE_ID )
-  {
-    glui2->disable();
-  }
-  else if ( control == SHOW_ID )
-  {
-    glui2->show();
-  }
-  else if ( control == HIDE_ID )
-  {
-    glui2->hide();
-  }
-}
 
 /**************************************** myGlutKeyboard() **********/
 
@@ -313,6 +237,28 @@ void myGlutDisplay()
   glutSwapBuffers(); 
 }
 
+void lightEnable(int enable, GLenum light, GLUI_Control * control)
+{
+  if (enable)
+  {
+    glEnable( light );
+    if (control) control->enable();
+  }
+  else
+  {
+    glDisable( light ); 
+    if (control) control->disable();
+  }
+}
+
+void lightIntensity(const float * const diffuse, float intensity, GLenum light)
+{
+  float v[] = { diffuse[0],  diffuse[1], diffuse[2],  diffuse[3] };
+  v[0] *= intensity;
+  v[1] *= intensity;
+  v[2] *= intensity;
+  glLightfv(light, GL_DIFFUSE, v );
+}
 
 /**************************************** main() ********************/
 
@@ -372,7 +318,7 @@ int main(int argc, char* argv[])
 
   /***** Control for object params *****/
 
-  new GLUI_Checkbox( obj_panel, "Wireframe", &wireframe, 1, control_cb );
+  new GLUI_Checkbox( obj_panel, "Wireframe", &wireframe);
   GLUI_Spinner *spinner = 
     new GLUI_Spinner( obj_panel, "Segments:", &segments);
   spinner->set_int_limits( 3, 60 );
@@ -391,38 +337,38 @@ int main(int argc, char* argv[])
   GLUI_Panel *light0 = new GLUI_Panel( roll_lights, "Light 1" );
   GLUI_Panel *light1 = new GLUI_Panel( roll_lights, "Light 2" );
 
-  new GLUI_Checkbox( light0, "Enabled", &light0_enabled,
-                     LIGHT0_ENABLED_ID, control_cb );
+  new GLUI_Checkbox( light0, "Enabled", &light0_enabled, std::bind(lightEnable, std::cref(light0_enabled), GL_LIGHT0, light0_spinner));
+
   light0_spinner = 
     new GLUI_Spinner( light0, "Intensity:", 
-                      &light0_intensity, LIGHT0_INTENSITY_ID,
-                      control_cb );
+                      &light0_intensity, std::bind(lightIntensity, light0_diffuse, std::cref(light0_intensity), GL_LIGHT0) );
   light0_spinner->set_float_limits( 0.0, 1.0 );
+
   GLUI_Scrollbar *sb;
   sb = new GLUI_Scrollbar( light0, "Red",GLUI_SCROLL_HORIZONTAL,
-                           &light0_diffuse[0],LIGHT0_INTENSITY_ID,control_cb);
+                           &light0_diffuse[0],std::bind(lightIntensity, light0_diffuse, std::cref(light0_intensity), GL_LIGHT0));
   sb->set_float_limits(0,1);
   sb = new GLUI_Scrollbar( light0, "Green",GLUI_SCROLL_HORIZONTAL,
-                           &light0_diffuse[1],LIGHT0_INTENSITY_ID,control_cb);
+                           &light0_diffuse[1],std::bind(lightIntensity, light0_diffuse, std::cref(light0_intensity), GL_LIGHT0));
   sb->set_float_limits(0,1);
   sb = new GLUI_Scrollbar( light0, "Blue",GLUI_SCROLL_HORIZONTAL,
-                           &light0_diffuse[2],LIGHT0_INTENSITY_ID,control_cb);
+                           &light0_diffuse[2],std::bind(lightIntensity, light0_diffuse, std::cref(light0_intensity), GL_LIGHT0));
   sb->set_float_limits(0,1);
-  new GLUI_Checkbox( light1, "Enabled", &light1_enabled,
-                     LIGHT1_ENABLED_ID, control_cb );
+
+  new GLUI_Checkbox( light1, "Enabled", &light1_enabled, std::bind(lightEnable, std::cref(light1_enabled), GL_LIGHT1, light1_spinner));
+
   light1_spinner = 
-    new GLUI_Spinner( light1, "Intensity:",
-                      &light1_intensity, LIGHT1_INTENSITY_ID,
-                      control_cb );
+    new GLUI_Spinner( light1, "Intensity:", 
+                      &light1_intensity, std::bind(lightIntensity, light1_diffuse, std::cref(light1_intensity), GL_LIGHT1) );
   light1_spinner->set_float_limits( 0.0, 1.0 );
   sb = new GLUI_Scrollbar( light1, "Red",GLUI_SCROLL_HORIZONTAL,
-                           &light1_diffuse[0],LIGHT1_INTENSITY_ID,control_cb);
+                          &light1_intensity, std::bind(lightIntensity, light1_diffuse, std::cref(light1_intensity), GL_LIGHT1) );
   sb->set_float_limits(0,1);
   sb = new GLUI_Scrollbar( light1, "Green",GLUI_SCROLL_HORIZONTAL,
-                           &light1_diffuse[1],LIGHT1_INTENSITY_ID,control_cb);
+                          &light1_intensity, std::bind(lightIntensity, light1_diffuse, std::cref(light1_intensity), GL_LIGHT1) );
   sb->set_float_limits(0,1);
   sb = new GLUI_Scrollbar( light1, "Blue",GLUI_SCROLL_HORIZONTAL,
-                           &light1_diffuse[2],LIGHT1_INTENSITY_ID,control_cb);
+                          &light1_intensity, std::bind(lightIntensity, light1_diffuse, std::cref(light1_intensity), GL_LIGHT1) );
   sb->set_float_limits(0,1);
 
 
@@ -444,15 +390,15 @@ int main(int argc, char* argv[])
 
 
   /*** Disable/Enable buttons ***/
-  new GLUI_Button( glui, "Disable movement", DISABLE_ID, control_cb );
-  new GLUI_Button( glui, "Enable movement", ENABLE_ID, control_cb );
-  new GLUI_Button( glui, "Hide", HIDE_ID, control_cb );
-  new GLUI_Button( glui, "Show", SHOW_ID, control_cb );
+  new GLUI_Button( glui, "Disable movement", [&]() { glui2->disable(); } );
+  new GLUI_Button( glui, "Enable movement",  [&]() { glui2->enable(); } );
+  new GLUI_Button( glui, "Hide", [&]() { glui2->hide(); } );
+  new GLUI_Button( glui, "Show", [&]() { glui2->show(); } );
 
   new GLUI_StaticText( glui, "" );
 
   /****** A 'quit' button *****/
-  new GLUI_Button( glui, "Quit", 0,(GLUI_Update_CB)exit );
+  new GLUI_Button( glui, "Quit", []() { exit(0); });
 
 
   /**** Link windows to GLUI, and register idle callback ******/

--- a/glui.cpp
+++ b/glui.cpp
@@ -114,14 +114,6 @@ static void finish_drawing()
 	glFinish();
 }
 
-/************************************ GLUI_CB::operator()() ************/
-void GLUI_CB::operator()(GLUI_Control*ctrl) const
-{
-  if (idCB)  idCB(ctrl->user_id);
-  if (objCB) objCB(ctrl);
-}
-
-
 /************************************************ GLUI::GLUI() **********/
 
 int GLUI::init( const GLUI_String &text, long flags, int x, int y, int parent_window )
@@ -690,6 +682,7 @@ void    GLUI_Main::keyboard(unsigned char key, int x, int y)
   if ( key == '\t' AND !mouse_button_down AND
        (!active_control || !active_control->wants_tabs())) {
     if ( curr_modifiers & GLUT_ACTIVE_SHIFT ) {
+      // Note that shift-tab doesn't seem to work on Mac
       new_control = find_prev_control( active_control );
     }
     else {
@@ -1676,15 +1669,15 @@ void GLUI_Master_Object::set_glutDisplayFunc(void (*f)(void)) {glutDisplayFunc(f
 void GLUI_Master_Object::set_glutTimerFunc(unsigned int millis, void (*f)(int value), int value)
 { ::glutTimerFunc(millis,f,value);}
 void GLUI_Master_Object::set_glutOverlayDisplayFunc(void(*f)(void)){glutOverlayDisplayFunc(f);}
-void GLUI_Master_Object::set_glutSpaceballMotionFunc(Int3_CB f)  {glutSpaceballMotionFunc(f);}
-void GLUI_Master_Object::set_glutSpaceballRotateFunc(Int3_CB f)  {glutSpaceballRotateFunc(f);}
-void GLUI_Master_Object::set_glutSpaceballButtonFunc(Int2_CB f)  {glutSpaceballButtonFunc(f);}
-void GLUI_Master_Object::set_glutTabletMotionFunc(Int2_CB f)        {glutTabletMotionFunc(f);}
-void GLUI_Master_Object::set_glutTabletButtonFunc(Int4_CB f)        {glutTabletButtonFunc(f);}
-void GLUI_Master_Object::set_glutMenuStatusFunc(Int3_CB f)            {glutMenuStatusFunc(f);}
-void GLUI_Master_Object::set_glutMenuStateFunc(Int1_CB f)              {glutMenuStateFunc(f);}
-void GLUI_Master_Object::set_glutButtonBoxFunc(Int2_CB f)              {glutButtonBoxFunc(f);}
-void GLUI_Master_Object::set_glutDialsFunc(Int2_CB f)                      {glutDialsFunc(f);}  
+void GLUI_Master_Object::set_glutSpaceballMotionFunc(void (*f)(int, int, int))   {glutSpaceballMotionFunc(f);}
+void GLUI_Master_Object::set_glutSpaceballRotateFunc(void (*f)(int, int, int))   {glutSpaceballRotateFunc(f);}
+void GLUI_Master_Object::set_glutSpaceballButtonFunc(void (*f)(int, int))        {glutSpaceballButtonFunc(f);}
+void GLUI_Master_Object::set_glutTabletMotionFunc(void (*f)(int, int))           {glutTabletMotionFunc(f);}
+void GLUI_Master_Object::set_glutTabletButtonFunc(void (*f)(int, int, int, int)) {glutTabletButtonFunc(f);}
+void GLUI_Master_Object::set_glutMenuStatusFunc(void (*f)(int, int, int))        {glutMenuStatusFunc(f);}
+void GLUI_Master_Object::set_glutMenuStateFunc(void (*f)(int))                   {glutMenuStateFunc(f);}
+void GLUI_Master_Object::set_glutButtonBoxFunc(void (*f)(int, int))              {glutButtonBoxFunc(f);}
+void GLUI_Master_Object::set_glutDialsFunc(void (*f)(int, int))                  {glutDialsFunc(f);}  
 
 /****************************** glui_parent_window_reshape_func() **********/
 /* This is the reshape callback for a window that contains subwindows      */

--- a/glui_add_controls.cpp
+++ b/glui_add_controls.cpp
@@ -41,10 +41,10 @@ that aren't used.
 /*********************************** GLUI:: add_checkbox() ************/
 
 GLUI_Checkbox   *GLUI:: add_checkbox( const GLUI_String &name, int *value_ptr,
-                                      int id, GLUI_CB callback )
+                                      GLUI_CB callback )
 {
   return add_checkbox_to_panel( main_panel,
-				name, value_ptr, id, callback );
+				name, value_ptr, callback );
 }
 
 
@@ -52,10 +52,9 @@ GLUI_Checkbox   *GLUI:: add_checkbox( const GLUI_String &name, int *value_ptr,
 
 GLUI_Checkbox   *GLUI::add_checkbox_to_panel( GLUI_Panel *panel,
 					      const GLUI_String &name, int *value_ptr,
-					      int id,
 					      GLUI_CB callback )
 {
-  return new GLUI_Checkbox( panel, name, value_ptr, id, callback );
+  return new GLUI_Checkbox( panel, name, value_ptr, callback );
 }
 
 /********************************************* GLUI::add_panel() *************/
@@ -77,11 +76,9 @@ GLUI_Panel *GLUI::add_panel_to_panel( GLUI_Panel *parent_panel,
 
 /***************************** GLUI::add_radiogroup() ***************/
 
-GLUI_RadioGroup *GLUI::add_radiogroup( int *value_ptr,
-				       int user_id, GLUI_CB callback)
+GLUI_RadioGroup *GLUI::add_radiogroup( int *value_ptr, GLUI_CB callback)
 {
-  return add_radiogroup_to_panel( main_panel, value_ptr,
-				  user_id, callback );
+  return add_radiogroup_to_panel( main_panel, value_ptr, callback );
 }
 
 
@@ -89,10 +86,10 @@ GLUI_RadioGroup *GLUI::add_radiogroup( int *value_ptr,
 
 GLUI_RadioGroup *GLUI::add_radiogroup_to_panel(
   GLUI_Panel *panel, int *value_ptr,
-  int user_id, GLUI_CB callback
+  GLUI_CB callback
   )
 {
-  return new GLUI_RadioGroup( panel, value_ptr, user_id, callback );
+  return new GLUI_RadioGroup( panel, value_ptr, callback );
 }
 
 
@@ -124,21 +121,17 @@ GLUI_StaticText *GLUI::add_statictext_to_panel( GLUI_Panel *panel,
 
 /***************************************** GLUI:: add_button() ************/
 
-GLUI_Button   *GLUI:: add_button( const GLUI_String &name,
-				  int id, GLUI_CB callback )
+GLUI_Button   *GLUI:: add_button( const GLUI_String &name, GLUI_CB callback )
 {
   return add_button_to_panel( main_panel,
-                              name, id, callback );
+                              name, callback );
 }
 
 /*********************************** GLUI:: add_button_to_panel() **********/
 
-GLUI_Button   *GLUI::add_button_to_panel( GLUI_Panel *panel,
-					  const GLUI_String &name,
-					  int id,
-					  GLUI_CB callback )
+GLUI_Button   *GLUI::add_button_to_panel( GLUI_Panel *panel, const GLUI_String &name, GLUI_CB callback )
 {
-  return new GLUI_Button( panel, name, id, callback );
+  return new GLUI_Button( panel, name, callback );
 }
 
 /********************************** GLUI::add_separator() ************/
@@ -161,10 +154,10 @@ void      GLUI::add_separator_to_panel( GLUI_Panel *panel )
 
 GLUI_EditText  *GLUI::add_edittext( const GLUI_String &name,
 				    int data_type, void *data,
-				    int id, GLUI_CB callback)
+				    GLUI_CB callback)
 {
   return add_edittext_to_panel( main_panel, name, data_type, data,
-                                id, callback );
+                                callback );
 }
 
 
@@ -173,18 +166,18 @@ GLUI_EditText  *GLUI::add_edittext( const GLUI_String &name,
 GLUI_EditText  *GLUI::add_edittext_to_panel( GLUI_Panel *panel,
                                              const GLUI_String &name,
                                              int data_type, void *data,
-                                             int id, GLUI_CB callback)
+                                             GLUI_CB callback)
 {
-  return new GLUI_EditText( panel, name, data_type, data, id, callback );
+  return new GLUI_EditText( panel, name, data_type, data, callback );
 }
 
 /********************************** GLUI::add_edittext() ************/
 
 GLUI_EditText  *GLUI::add_edittext( const GLUI_String &name,
                                     GLUI_String & data,
-                                    int id, GLUI_CB callback)
+                                    GLUI_CB callback)
 {
-  return add_edittext_to_panel( main_panel, name, data, id, callback );
+  return add_edittext_to_panel( main_panel, name, data, callback );
 }
 
 
@@ -193,19 +186,18 @@ GLUI_EditText  *GLUI::add_edittext( const GLUI_String &name,
 GLUI_EditText*
 GLUI::add_edittext_to_panel( GLUI_Panel *panel, const GLUI_String &name,
                              GLUI_String& data,
-                             int id, GLUI_CB callback)
+                             GLUI_CB callback)
 {
-  return new GLUI_EditText( panel, name, GLUI_EDITTEXT_STRING, &data, id, callback );
+  return new GLUI_EditText( panel, name, GLUI_EDITTEXT_STRING, &data, callback );
 }
 
 /********************************** GLUI::add_spinner() ************/
 
 GLUI_Spinner  *GLUI::add_spinner( const GLUI_String &name,
 				  int data_type, void *data,
-				  int id, GLUI_CB callback)
+				  GLUI_CB callback)
 {
-  return add_spinner_to_panel( main_panel, name, data_type, data,
-			       id, callback );
+  return add_spinner_to_panel( main_panel, name, data_type, data, callback );
 }
 
 
@@ -214,10 +206,10 @@ GLUI_Spinner  *GLUI::add_spinner( const GLUI_String &name,
 GLUI_Spinner  *GLUI::add_spinner_to_panel(
   GLUI_Panel *panel, const GLUI_String &name,
   int data_type, void *data,
-  int id, GLUI_CB callback
+  GLUI_CB callback
 )
 {
-  return new GLUI_Spinner( panel, name, data_type, data, id, callback );
+  return new GLUI_Spinner( panel, name, data_type, data, callback );
 }
 
 
@@ -239,11 +231,10 @@ void   GLUI::add_column_to_panel( GLUI_Panel *panel, int draw_bar )
 
 /*********************************** GLUI:: add_listbox() ************/
 
-GLUI_Listbox   *GLUI:: add_listbox( const GLUI_String &name, int *value_ptr,
-				    int id, GLUI_CB callback )
+GLUI_Listbox   *GLUI:: add_listbox( const GLUI_String &name, int *value_ptr, GLUI_CB callback)
 {
   return add_listbox_to_panel( main_panel,
-                               name, value_ptr, id, callback );
+                               name, value_ptr, callback );
 }
 
 
@@ -251,19 +242,17 @@ GLUI_Listbox   *GLUI:: add_listbox( const GLUI_String &name, int *value_ptr,
 
 GLUI_Listbox   *GLUI::add_listbox_to_panel( GLUI_Panel *panel,
                                             const GLUI_String &name, int *value_ptr,
-                                            int id,
                                             GLUI_CB callback )
 {
-  return new GLUI_Listbox( panel, name, value_ptr, id, callback );
+  return new GLUI_Listbox( panel, name, value_ptr, callback );
 }
 
 
 /*********************************** GLUI:: add_rotation() ************/
 
-GLUI_Rotation   *GLUI:: add_rotation( const GLUI_String &name, float *value_ptr,
-                                      int id, GLUI_CB callback )
+GLUI_Rotation   *GLUI:: add_rotation( const GLUI_String &name, float *value_ptr, GLUI_CB callback )
 {
-  return add_rotation_to_panel( main_panel, name, value_ptr, id, callback );
+  return add_rotation_to_panel( main_panel, name, value_ptr, callback );
 }
 
 
@@ -271,21 +260,20 @@ GLUI_Rotation   *GLUI:: add_rotation( const GLUI_String &name, float *value_ptr,
 
 GLUI_Rotation *GLUI::add_rotation_to_panel( GLUI_Panel *panel,
                                             const GLUI_String &name, float *value_ptr,
-                                            int id,
                                             GLUI_CB callback )
 {
-  return new GLUI_Rotation( panel, name, value_ptr, id, callback );
+  return new GLUI_Rotation( panel, name, value_ptr, callback );
 }
 
 
 /*********************************** GLUI:: add_translation() ************/
 
 GLUI_Translation *GLUI:: add_translation( const GLUI_String &name, int trans_type,
-                                          float *value_ptr, int id,
+                                          float *value_ptr, 
                                           GLUI_CB callback )
 {
   return add_translation_to_panel( main_panel,name,trans_type,
-                                   value_ptr, id, callback );
+                                   value_ptr, callback );
 }
 
 
@@ -294,10 +282,10 @@ GLUI_Translation *GLUI:: add_translation( const GLUI_String &name, int trans_typ
 GLUI_Translation *GLUI::add_translation_to_panel(
   GLUI_Panel *panel, const GLUI_String &name,
   int trans_type, float *value_ptr,
-  int id, GLUI_CB callback
+  GLUI_CB callback
   )
 {
-  return new GLUI_Translation(panel, name, trans_type, value_ptr, id, callback);
+  return new GLUI_Translation(panel, name, trans_type, value_ptr, callback);
 }
 
 

--- a/glui_button.cpp
+++ b/glui_button.cpp
@@ -36,11 +36,9 @@
 
 /****************************** GLUI_Button::GLUI_Button() **********/
 
-GLUI_Button::GLUI_Button( GLUI_Node *parent, const GLUI_String &name,
-                          int id, GLUI_CB cb )
+GLUI_Button::GLUI_Button( GLUI_Node *parent, const GLUI_String &name, GLUI_CB cb )
 {
   common_init();
-  user_id     = id;
   callback    = cb;
   set_name( name );
   currently_inside = false;

--- a/glui_checkbox.cpp
+++ b/glui_checkbox.cpp
@@ -40,14 +40,12 @@
 
 GLUI_Checkbox::GLUI_Checkbox( GLUI_Node *parent,
                               const GLUI_String &name, int *value_ptr,
-                              int id,
                               GLUI_CB cb )
 {
   common_init();
 
   set_ptr_val( value_ptr );
   set_name( name );
-  user_id    = id;
   callback   = cb;
 
   parent->add_control( this );

--- a/glui_commandline.cpp
+++ b/glui_commandline.cpp
@@ -35,14 +35,13 @@
 
 /****************************** GLUI_CommandLine::GLUI_CommandLine() **********/
 GLUI_CommandLine::GLUI_CommandLine( GLUI_Node *parent, const GLUI_String &name,
-                                    void *data, int id, GLUI_CB cb )
+                                    void *data, GLUI_CB cb )
 {
   common_init();
   set_name( name );
 
   data_type   = GLUI_EDITTEXT_TEXT;
   ptr_val     = data;
-  user_id     = id;
   callback    = cb;
 
   live_type = GLUI_LIVE_TEXT;

--- a/glui_control.cpp
+++ b/glui_control.cpp
@@ -996,9 +996,7 @@ void GLUI_Control::execute_callback()
   if ( glui AND glui->main_gfx_window_id != -1 )
     glutSetWindow( glui->main_gfx_window_id );
 
-  this->callback( this );
-//  if ( this->callback )
-//    this->callback( this->user_id );
+  if (callback) callback();
 
   glutSetWindow( old_window );
 }

--- a/glui_edittext.cpp
+++ b/glui_edittext.cpp
@@ -42,7 +42,7 @@
 
 GLUI_EditText::GLUI_EditText( GLUI_Node *parent, const GLUI_String &name,
                              int data_type, void *live_var,
-                             int id, GLUI_CB callback )
+                             GLUI_CB callback )
 {
   if (data_type == GLUI_EDITTEXT_TEXT) {
     live_type = GLUI_LIVE_TEXT;
@@ -59,57 +59,57 @@ GLUI_EditText::GLUI_EditText( GLUI_Node *parent, const GLUI_String &name,
   else if (data_type == GLUI_EDITTEXT_FLOAT) {
     live_type = GLUI_LIVE_FLOAT;
   }
-  common_construct( parent, name, data_type, live_type, live_var, id, callback );
+  common_construct( parent, name, data_type, live_type, live_var, callback );
 }
 
 /****************************** GLUI_EditText::GLUI_EditText() **********/
 
 GLUI_EditText::GLUI_EditText( GLUI_Node *parent, const GLUI_String &name,
-                              int text_type, int id, GLUI_CB callback )
+                              int text_type, GLUI_CB callback )
 {
-  common_construct( parent, name, text_type, GLUI_LIVE_NONE, 0, id, callback);
+  common_construct( parent, name, text_type, GLUI_LIVE_NONE, 0, callback);
 }
 
 /****************************** GLUI_EditText::GLUI_EditText() **********/
 
 GLUI_EditText::GLUI_EditText( GLUI_Node *parent, const GLUI_String &name,
                               int *live_var,
-                              int id, GLUI_CB callback )
+                              GLUI_CB callback )
 {
-  common_construct( parent, name, GLUI_EDITTEXT_INT, GLUI_LIVE_INT, live_var, id, callback);
+  common_construct( parent, name, GLUI_EDITTEXT_INT, GLUI_LIVE_INT, live_var, callback);
 }
 
 /****************************** GLUI_EditText::GLUI_EditText() **********/
 
 GLUI_EditText::GLUI_EditText( GLUI_Node *parent, const GLUI_String &name,
                               float *live_var,
-                              int id, GLUI_CB callback )
+                              GLUI_CB callback )
 {
-  common_construct( parent, name, GLUI_EDITTEXT_FLOAT, GLUI_LIVE_FLOAT, live_var, id, callback);
+  common_construct( parent, name, GLUI_EDITTEXT_FLOAT, GLUI_LIVE_FLOAT, live_var, callback);
 }
 
 /****************************** GLUI_EditText::GLUI_EditText() **********/
 
 GLUI_EditText::GLUI_EditText( GLUI_Node *parent, const GLUI_String &name,
-                              GLUI_String *live_var,
-                              int id, GLUI_CB callback )
+                              char *live_var,
+                              GLUI_CB callback )
 {
-  common_construct( parent, name, GLUI_EDITTEXT_TEXT, GLUI_LIVE_TEXT, live_var, id, callback);
+  common_construct( parent, name, GLUI_EDITTEXT_TEXT, GLUI_LIVE_TEXT, live_var, callback);
 }
 
 /****************************** GLUI_EditText::GLUI_EditText() **********/
 
 GLUI_EditText::GLUI_EditText( GLUI_Node *parent, const GLUI_String &name,
                               std::string &live_var,
-                              int id, GLUI_CB callback )
+                              GLUI_CB callback )
 {
-  common_construct( parent, name, GLUI_EDITTEXT_TEXT, GLUI_LIVE_STRING, &live_var, id, callback);
+  common_construct( parent, name, GLUI_EDITTEXT_TEXT, GLUI_LIVE_STRING, &live_var, callback);
 }
 
 /****************************** GLUI_EditText::common_construct() **********/
 
 void GLUI_EditText::common_construct( GLUI_Node *parent, const GLUI_String &name,
-                                      int data_t, int live_t, void *data, int id,
+                                      int data_t, int live_t, void *data,
                                       GLUI_CB cb )
 {
   common_init();
@@ -118,7 +118,6 @@ void GLUI_EditText::common_construct( GLUI_Node *parent, const GLUI_String &name
   live_type   = live_t;
   data_type   = data_t;
   ptr_val     = data;
-  user_id     = id;
   callback    = cb;
 
 
@@ -523,7 +522,7 @@ void    GLUI_EditText::deactivate()
       /* THE CODE BELOW IS FROM WHEN SPINNER ALSO MAINTAINED CALLBACKS    */
       if ( spinner == NULL ) {   /** Are we independent of a spinner?  **/
         if ( callback ) {
-          callback( this );
+          callback();
         }
       }
       else {                      /* We're attached to a spinner */

--- a/glui_filebrowser.cpp
+++ b/glui_filebrowser.cpp
@@ -47,19 +47,17 @@
 GLUI_FileBrowser::GLUI_FileBrowser( GLUI_Node *parent,
                                     const GLUI_String &name,
                                     int type,
-                                    int id,
                                     GLUI_CB cb)
 {
   common_init();
 
   set_name( name );
-  user_id    = id;
   int_val    = type;
   callback   = cb;
 
   parent->add_control( this );
-  list = new GLUI_List(this, true, 1);
-  list->set_object_callback( GLUI_FileBrowser::dir_list_callback, this );
+  list = new GLUI_List(this, true);
+  list->set_object_callback( [=]() { GLUI_FileBrowser::dir_list_callback(this); });
   list->set_click_type(GLUI_DOUBLE_CLICK);
   this->fbreaddir(this->current_dir.c_str());
 }
@@ -67,6 +65,7 @@ GLUI_FileBrowser::GLUI_FileBrowser( GLUI_Node *parent,
 /****************************** GLUI_FileBrowser::draw() **********/
 
 void GLUI_FileBrowser::dir_list_callback(GLUI_Control *glui_object) {
+  printf("GLUI_FileBrowser::dir_list_callback\n");
   GLUI_List *list = dynamic_cast<GLUI_List*>(glui_object);
   if (!list)
     return;

--- a/glui_list.cpp
+++ b/glui_list.cpp
@@ -38,23 +38,18 @@
 /****************************** GLUI_List::GLUI_List() **********/
 
 GLUI_List::GLUI_List( GLUI_Node *parent, bool scroll,
-                      int id, GLUI_CB callback
-                      /*,GLUI_Control *object
-                      GLUI_InterObject_CB obj_cb*/)
+                      GLUI_CB callback)
 {
-  common_construct(parent, NULL, scroll, id, callback/*, object, obj_cb*/);
+  common_construct(parent, NULL, scroll, callback);
 }
 
 /****************************** GLUI_List::GLUI_List() **********/
 
 GLUI_List::GLUI_List( GLUI_Node *parent,
                       GLUI_String& live_var, bool scroll,
-                      int id,
-                      GLUI_CB callback
-                      /* ,GLUI_Control *object
-                      ,GLUI_InterObject_CB obj_cb*/ )
+                      GLUI_CB callback)
 {
-  common_construct(parent, &live_var, scroll, id, callback/*, object, obj_cb*/);
+  common_construct(parent, &live_var, scroll, callback);
 }
 
 /****************************** GLUI_List::common_construct() **********/
@@ -62,7 +57,6 @@ GLUI_List::GLUI_List( GLUI_Node *parent,
 void GLUI_List::common_construct(
   GLUI_Node *parent,
   GLUI_String* data, bool scroll,
-  int id,
   GLUI_CB callback
   /*,GLUI_Control *object
   , GLUI_InterObject_CB obj_cb*/)
@@ -79,7 +73,6 @@ void GLUI_List::common_construct(
   if (data) {
     this->live_type = GLUI_LIVE_STRING;
   }
-  this->user_id     = id;
   this->callback    = callback;
   this->name        = "list";
   list_panel->add_control( this );
@@ -91,7 +84,7 @@ void GLUI_List::common_construct(
                          "scrollbar",
                          GLUI_SCROLL_VERTICAL,
                          GLUI_SCROLL_INT);
-    scrollbar->set_object_callback(GLUI_List::scrollbar_callback, this);
+    scrollbar->set_object_callback([=]() { GLUI_List::scrollbar_callback(this); });
     scrollbar->set_alignment(GLUI_ALIGN_LEFT);
     // scrollbar->can_activate = false; //kills ability to mouse drag too
   }
@@ -121,14 +114,10 @@ int    GLUI_List::mouse_down_handler( int local_x, int local_y )
     this->execute_callback();
     if (associated_object != NULL)
       if (cb_click_type == GLUI_SINGLE_CLICK) {
-        if (obj_cb) {
-          // obj_cb(associated_object, user_id);
-          obj_cb(this);
-        }
+        if (obj_cb) obj_cb();
       } else {
         if (last_line == curr_line && (ms - last_click_time) < 300) {
-          //obj_cb(associated_object, user_id);
-          obj_cb(this);
+          if (obj_cb) obj_cb();
         } else {
           last_click_time = ms;
           last_line = curr_line;

--- a/glui_listbox.cpp
+++ b/glui_listbox.cpp
@@ -40,12 +40,10 @@
 /****************************** GLUI_Listbox::GLUI_Listbox() **********/
 GLUI_Listbox::GLUI_Listbox( GLUI_Node *parent,
                             const GLUI_String &name, int *value_ptr,
-                            int id,
                             GLUI_CB cb)
 {
   common_init();
   set_ptr_val( value_ptr );
-  user_id    = id;
   set_name( name );
   callback    = cb;
 

--- a/glui_panel.cpp
+++ b/glui_panel.cpp
@@ -37,7 +37,6 @@ GLUI_Panel::GLUI_Panel( GLUI_Node *parent, const GLUI_String &name, int type )
 {
   common_init();
   set_name( name );
-  user_id    = -1;
   int_val    = type;
 
   parent->add_control( this );

--- a/glui_radio.cpp
+++ b/glui_radio.cpp
@@ -41,7 +41,7 @@
 
 GLUI_RadioGroup::GLUI_RadioGroup(GLUI_Node *parent,
                                  int *value_ptr,
-                                 int id, GLUI_CB cb)
+                                 GLUI_CB cb)
 {
   common_init();
 
@@ -54,10 +54,8 @@ GLUI_RadioGroup::GLUI_RadioGroup(GLUI_Node *parent,
     last_live_int = *value_ptr;
   }
 
-  user_id    = id;
-  GLUI_String buf = tfm::format("RadioGroup: %p", this );
-  set_name( buf.c_str() );
-  callback   = cb;
+  set_name( tfm::format("RadioGroup: %p", this ) );
+  callback = cb;
 
   parent->add_control( this );
 

--- a/glui_rollout.cpp
+++ b/glui_rollout.cpp
@@ -42,7 +42,6 @@ GLUI_Rollout::GLUI_Rollout( GLUI_Node *parent, const GLUI_String &name,
 {
   common_init();
   set_name( name );
-  user_id    = -1;
   int_val    = type;
 
   if ( NOT open ) {

--- a/glui_rotation.cpp
+++ b/glui_rotation.cpp
@@ -419,12 +419,10 @@ void   GLUI_Rotation::set_spin( float damp_factor )
 
 GLUI_Rotation::GLUI_Rotation( GLUI_Node *parent,
                               const GLUI_String &name, float *value_ptr,
-                              int id,
                               GLUI_CB cb )
 {
   common_init();
   set_ptr_val( value_ptr );
-  user_id    = id;
   set_name( name );
   callback    = cb;
   parent->add_control( this );

--- a/glui_scrollbar.cpp
+++ b/glui_scrollbar.cpp
@@ -54,12 +54,10 @@ GLUI_Scrollbar::GLUI_Scrollbar( GLUI_Node *parent,
                                 const GLUI_String &name,
                                 int horz_vert,
                                 int data_type,
-                                int id, GLUI_CB callback
-                                /*,GLUI_Control *object
-                                ,GLUI_InterObject_CB obj_cb*/
+                                GLUI_CB callback
                                 )
 {
-  common_construct(parent, name, horz_vert, data_type, NULL, id, callback/*, object, obj_cb*/);
+  common_construct(parent, name, horz_vert, data_type, NULL, callback/*, object, obj_cb*/);
 }
 
 /****************************** GLUI_Scrollbar::GLUI_Scrollbar() **********/
@@ -67,12 +65,10 @@ GLUI_Scrollbar::GLUI_Scrollbar( GLUI_Node *parent,
 GLUI_Scrollbar::GLUI_Scrollbar( GLUI_Node *parent, const GLUI_String &name,
                                 int horz_vert,
                                 int *live_var,
-                                int id, GLUI_CB callback
-                                /*,GLUI_Control *object
-                                ,GLUI_InterObject_CB obj_cb*/
+                                GLUI_CB callback
                                 )
 {
-  common_construct(parent, name, horz_vert, GLUI_SCROLL_INT, live_var, id, callback/*, object, obj_cb*/);
+  common_construct(parent, name, horz_vert, GLUI_SCROLL_INT, live_var, callback/*, object, obj_cb*/);
 }
 
 /****************************** GLUI_Scrollbar::GLUI_Scrollbar() **********/
@@ -80,12 +76,10 @@ GLUI_Scrollbar::GLUI_Scrollbar( GLUI_Node *parent, const GLUI_String &name,
 GLUI_Scrollbar::GLUI_Scrollbar( GLUI_Node *parent, const GLUI_String &name,
                                 int horz_vert,
                                 float *live_var,
-                                int id, GLUI_CB callback
-                                /*,GLUI_Control *object
-                                ,GLUI_InterObject_CB obj_cb*/
+                                GLUI_CB callback
                                 )
 {
-  common_construct(parent, name, horz_vert, GLUI_SCROLL_FLOAT, live_var, id, callback/*, object, obj_cb*/);
+  common_construct(parent, name, horz_vert, GLUI_SCROLL_FLOAT, live_var, callback/*, object, obj_cb*/);
 }
 
 /****************************** GLUI_Scrollbar::common_init() **********/
@@ -124,9 +118,7 @@ void GLUI_Scrollbar::common_construct(
   int horz_vert,
   int data_type,
   void *data,
-  int id, GLUI_CB callback
-  /*,GLUI_Control *object,
-  GLUI_InterObject_CB obj_cb*/
+  GLUI_CB callback
   )
 {
   common_init();
@@ -156,7 +148,6 @@ void GLUI_Scrollbar::common_construct(
   this->data_type = data_type;
   this->set_ptr_val( data );
   this->set_name(name);
-  this->user_id = id;
   this->callback    = callback;
   //this->associated_object = object;
   //this->object_cb = obj_cb;
@@ -731,10 +722,7 @@ void    GLUI_Scrollbar::do_callbacks()
     this->execute_callback();
   }
   else  {                      // Use internal Callbacks
-    if (object_cb) {
-      //object_cb(associated_object, int_val);
-      object_cb(this);
-    }
+    if (object_cb) object_cb();
   }
   last_int_val   = int_val;
   last_float_val = float_val;

--- a/glui_spinner.cpp
+++ b/glui_spinner.cpp
@@ -76,46 +76,43 @@ void GLUI_Spinner::common_init()
 /****************************** GLUI_Spinner::GLUI_Spinner() ****************/
 
 GLUI_Spinner::GLUI_Spinner( GLUI_Node* parent, const GLUI_String &name,
-                            int data_type, int id, GLUI_CB callback )
+                            int data_type, GLUI_CB callback )
 {
-  common_construct(parent, name, data_type, NULL, id, callback);
+  common_construct(parent, name, data_type, NULL, callback);
 }
 
 /****************************** GLUI_Spinner::GLUI_Spinner() ****************/
 
 GLUI_Spinner::GLUI_Spinner( GLUI_Node* parent, const GLUI_String &name,
-                            int *live_var, int id, GLUI_CB callback )
+                            int *live_var, GLUI_CB callback )
 {
-  common_construct(parent, name, GLUI_SPINNER_INT, live_var, id, callback);
+  common_construct(parent, name, GLUI_SPINNER_INT, live_var, callback);
 }
 
 /****************************** GLUI_Spinner::GLUI_Spinner() ****************/
 
 GLUI_Spinner::GLUI_Spinner( GLUI_Node* parent, const GLUI_String &name,
-             float *live_var, int id, GLUI_CB callback )
+             float *live_var, GLUI_CB callback )
 {
-  common_construct(parent, name, GLUI_SPINNER_FLOAT, live_var, id, callback);
+  common_construct(parent, name, GLUI_SPINNER_FLOAT, live_var, callback);
 }
 
 /****************************** GLUI_Spinner::GLUI_Spinner() ****************/
 
 GLUI_Spinner::GLUI_Spinner( GLUI_Node *parent, const GLUI_String &name,
                             int data_t, void *live_var,
-                            int id, GLUI_CB callback )
+                            GLUI_CB callback )
 {
-  common_construct(parent, name, data_t, live_var, id, callback);
+  common_construct(parent, name, data_t, live_var, callback);
 }
 
 /****************************** GLUI_Spinner::common_construct() ************/
 
 void GLUI_Spinner::common_construct( GLUI_Node* parent, const GLUI_String &name,
                                      int data_t, void *data,
-                                     int id, GLUI_CB cb )
+                                     GLUI_CB cb )
 {
   common_init();
-
-  if ( name!="Spinner Test" )
-    id=id;
 
   int text_type;
   if ( data_t == GLUI_SPINNER_INT ) {
@@ -128,7 +125,6 @@ void GLUI_Spinner::common_construct( GLUI_Node* parent, const GLUI_String &name,
     assert(0); /* Did not pass in a valid data type */
   }
 
-  user_id     = id;
   data_type   = data_t;
   callback    = cb;
   set_name( name );
@@ -137,7 +133,7 @@ void GLUI_Spinner::common_construct( GLUI_Node* parent, const GLUI_String &name,
   parent->add_control( this );
 
   GLUI_EditText *txt =
-    new GLUI_EditText( this, name, text_type, data, id, cb);
+    new GLUI_EditText( this, name, text_type, data, cb);
 
   edittext    = txt;  /* Link the edittext to the spinner */
   /*      control->ptr_val     = data;               */

--- a/glui_textbox.cpp
+++ b/glui_textbox.cpp
@@ -41,23 +41,23 @@ static const int LINE_HEIGHT = 15;
 /****************************** GLUI_TextBox::GLUI_TextBox() **********/
 
 GLUI_TextBox::GLUI_TextBox(GLUI_Node *parent, GLUI_String &live_var,
-                           bool scroll, int id, GLUI_CB callback )
+                           bool scroll, GLUI_CB callback )
 {
-  common_construct(parent, &live_var, scroll, id, callback);
+  common_construct(parent, &live_var, scroll, callback);
 }
 
 /****************************** GLUI_TextBox::GLUI_TextBox() **********/
 
-GLUI_TextBox::GLUI_TextBox( GLUI_Node *parent, bool scroll, int id,
+GLUI_TextBox::GLUI_TextBox( GLUI_Node *parent, bool scroll,
                             GLUI_CB callback )
 {
-  common_construct(parent, NULL, scroll, id, callback);
+  common_construct(parent, NULL, scroll, callback);
 }
 
 /****************************** GLUI_TextBox::common_construct() **********/
 void GLUI_TextBox::common_construct(
   GLUI_Node *parent, GLUI_String *data,
-  bool scroll, int id, GLUI_CB callback)
+  bool scroll, GLUI_CB callback)
 {
   common_init();
 
@@ -74,7 +74,6 @@ void GLUI_TextBox::common_construct(
   } else {
     this->live_type = GLUI_LIVE_NONE;
   }
-  this->user_id     = id;
   this->callback    = callback;
   this->name        = "textbox";
   tb_panel->add_control( this );
@@ -85,7 +84,7 @@ void GLUI_TextBox::common_construct(
                          "scrollbar",
                          GLUI_SCROLL_VERTICAL,
                          GLUI_SCROLL_INT);
-    scrollbar->set_object_callback(GLUI_TextBox::scrollbar_callback, this);
+    scrollbar->set_object_callback( [=]() { GLUI_TextBox::scrollbar_callback(this); });
     scrollbar->set_alignment(GLUI_ALIGN_LEFT);
     // scrollbar->can_activate = false; //kills ability to mouse drag too
   }

--- a/glui_translation.cpp
+++ b/glui_translation.cpp
@@ -43,12 +43,11 @@
 GLUI_Translation::GLUI_Translation(
   GLUI_Node *parent, const GLUI_String &name,
   int trans_t, float *value_ptr,
-  int id, GLUI_CB cb )
+  GLUI_CB cb )
 {
   common_init();
 
   set_ptr_val( value_ptr );
-  user_id    = id;
   set_name( name );
   callback    = cb;
   parent->add_control( this );

--- a/glui_tree.cpp
+++ b/glui_tree.cpp
@@ -38,7 +38,6 @@ GLUI_Tree::GLUI_Tree(GLUI_Node *parent, const GLUI_String &name,
   GLUI_Column     *col;
 
   this->set_name( name );
-  this->user_id    = -1;
 
   if ( NOT open ) {
     this->is_open = false;

--- a/glui_treepanel.cpp
+++ b/glui_treepanel.cpp
@@ -28,7 +28,6 @@ GLUI_TreePanel::GLUI_TreePanel(GLUI_Node *parent, const GLUI_String &name,
   common_init();
 
   set_name( name );
-  user_id    = -1;
 
   if ( !open ) {
     is_open = false;
@@ -169,7 +168,6 @@ void GLUI_TreePanel::initNode(GLUI_Tree *temp)
              dynamic_cast<GLUI_TreePanel*>(temp->parent())) {
     child_number = ++root_children;
   }
-  temp->set_id(uniqueID());     // -1 if unset
   temp->set_level(level);
   temp->set_child_number(child_number);
 }

--- a/makefile
+++ b/makefile
@@ -37,7 +37,7 @@ endif
 ifeq ($(UNAME), Darwin)
 CXX      ?= g++
 CPPFLAGS += $(OPTS) -Wall -pedantic
-LIBGL     = -framework OpenGL
+LIBGL     = -framework OpenGL -framework Carbon
 LIBGLUT   = -framework GLUT
 endif
 


### PR DESCRIPTION
This change replaces GLUI_CB and the associated IDs and pointers with simply `std::function<void(void)>`.  This allows for using C++ lambdas for GLUI callbacks, including `std::bind`.

For example:

`new GLUI_Button( glui, "Quit", []() { printf("Exit\n"); exit(0); } );`