### PR TITLE
Fix for GLUI_List double-click callback

### DIFF
--- a/glui_list.cpp
+++ b/glui_list.cpp
@@ -102,7 +102,7 @@ void GLUI_List::common_construct(
 int    GLUI_List::mouse_down_handler( int local_x, int local_y )
 {
   int tmp_line;
-  unsigned long int ms;
+  uint64_t ms;
   timeb time;
   ftime(&time);
   ms = time.millitm + (time.time)*1000;
@@ -126,7 +126,7 @@ int    GLUI_List::mouse_down_handler( int local_x, int local_y )
           obj_cb(this);
         }
       } else {
-        if (last_line == curr_line && (ms - last_click_time) < 300) {
+        if (last_line == curr_line && last_click_time && (ms - last_click_time) < 300) {
           //obj_cb(associated_object, user_id);
           obj_cb(this);
         } else {

--- a/include/GL/glui.h
+++ b/include/GL/glui.h
@@ -44,6 +44,7 @@
 
 #include <cstdlib>
 #include <cstdio>
+#include <cstdint>
 #include <cstring>
 
 #include <array>
@@ -2031,7 +2032,7 @@ public:
     GLUI_CB             obj_cb;
     int                 cb_click_type;
     int                 last_line;
-    int                 last_click_time;
+    uint64_t            last_click_time;
 
     int  mouse_down_handler( int local_x, int local_y ) override;
     int  mouse_up_handler( int local_x, int local_y, bool inside ) override;


### PR DESCRIPTION
Use uint64_t for timestamp storage.

Proposed fix for Issue #83 

