### PR TITLE
Resolve Apple Mac OpenGL deprecation warnings

### DIFF
--- a/example/example1.cpp
+++ b/example/example1.cpp
@@ -11,6 +11,12 @@
 
 ****************************************************************************/
 
+#ifdef __APPLE__
+#ifndef GL_SILENCE_DEPRECATION
+#define GL_SILENCE_DEPRECATION
+#endif
+#endif
+
 #include <string.h>
 #include <GL/glui.h>
 

--- a/example/example2.cpp
+++ b/example/example2.cpp
@@ -10,6 +10,12 @@
 
 ****************************************************************************/
 
+#ifdef __APPLE__
+#ifndef GL_SILENCE_DEPRECATION
+#define GL_SILENCE_DEPRECATION
+#endif
+#endif
+
 #include <string.h>
 #include <GL/glui.h>
 

--- a/example/example3.cpp
+++ b/example/example3.cpp
@@ -11,6 +11,12 @@
 
 ****************************************************************************/
 
+#ifdef __APPLE__
+#ifndef GL_SILENCE_DEPRECATION
+#define GL_SILENCE_DEPRECATION
+#endif
+#endif
+
 #include <string.h>
 #include <GL/glui.h>
 

--- a/example/example4.cpp
+++ b/example/example4.cpp
@@ -10,6 +10,12 @@
 
 ****************************************************************************/
 
+#ifdef __APPLE__
+#ifndef GL_SILENCE_DEPRECATION
+#define GL_SILENCE_DEPRECATION
+#endif
+#endif
+
 #include <string.h>
 #include <GL/glui.h>
 

--- a/example/example5.cpp
+++ b/example/example5.cpp
@@ -11,6 +11,12 @@
 
 ****************************************************************************/
 
+#ifdef __APPLE__
+#ifndef GL_SILENCE_DEPRECATION
+#define GL_SILENCE_DEPRECATION
+#endif
+#endif
+
 #include <string.h>
 #include <GL/glui.h>
 

--- a/example/example6.cpp
+++ b/example/example6.cpp
@@ -11,6 +11,12 @@
 
 ****************************************************************************/
 
+#ifdef __APPLE__
+#ifndef GL_SILENCE_DEPRECATION
+#define GL_SILENCE_DEPRECATION
+#endif
+#endif
+
 #include <string.h>
 #include <GL/glui.h>
 

--- a/src/glui_add_controls.cpp
+++ b/src/glui_add_controls.cpp
@@ -34,9 +34,7 @@ that aren't used.
 
 *****************************************************************************/
 
-#include "GL/glui.h"
-#include "glui_internal.h"
-
+#include "glui_internal_control.h"
 
 /*********************************** GLUI:: add_checkbox() ************/
 

--- a/src/glui_bitmaps.cpp
+++ b/src/glui_bitmaps.cpp
@@ -35,8 +35,8 @@ FIXME: upload the images to a texture.  This will allow them to be:
 
 *****************************************************************************/
 
-#include "GL/glui.h"
-#include "glui_internal.h"
+#include "glui_internal_control.h"
+
 #include "glui_bitmap_img_data.h"
 
 #include <cassert>

--- a/src/glui_commandline.cpp
+++ b/src/glui_commandline.cpp
@@ -30,8 +30,7 @@
 
 *****************************************************************************/
 
-#include "GL/glui.h"
-#include "glui_internal.h"
+#include "glui_internal_control.h"
 
 /****************************** GLUI_CommandLine::GLUI_CommandLine() **********/
 GLUI_CommandLine::GLUI_CommandLine( GLUI_Node *parent, const GLUI_String &name,

--- a/src/glui_filebrowser.cpp
+++ b/src/glui_filebrowser.cpp
@@ -29,8 +29,8 @@
 
 *****************************************************************************/
 
-#include "GL/glui.h"
-#include "glui_internal.h"
+#include "glui_internal_control.h"
+
 #include <sys/types.h>
 
 #ifdef __GNUC__

--- a/src/glui_internal_control.h
+++ b/src/glui_internal_control.h
@@ -22,6 +22,12 @@
 #ifndef __GLUI_INTERNAL_CONTROL_H
 #define __GLUI_INTERNAL_CONTROL_H
 
+#ifdef __APPLE__
+#ifndef GL_SILENCE_DEPRECATION
+#define GL_SILENCE_DEPRECATION
+#endif
+#endif
+
 /* This is the main GLUI external header */
 #include "GL/glui.h"
 

--- a/src/glui_node.cpp
+++ b/src/glui_node.cpp
@@ -31,8 +31,7 @@
 
 *****************************************************************************/
 
-#include "GL/glui.h"
-#include "glui_internal.h"
+#include "glui_internal_control.h"
 
 /********************************************* GLUI_Node::GLUI_Node() *******/
 

--- a/src/glui_rotation.cpp
+++ b/src/glui_rotation.cpp
@@ -31,7 +31,8 @@
 
 *****************************************************************************/
 
-#include "GL/glui.h"
+#include "glui_internal_control.h"
+
 #include "arcball.h"
 #include "algebra3.h"
 #include "tinyformat.h"

--- a/src/glui_translation.cpp
+++ b/src/glui_translation.cpp
@@ -31,8 +31,8 @@
 
 *****************************************************************************/
 
-#include "GL/glui.h"
-#include "glui_internal.h"
+#include "glui_internal_control.h"
+
 #include "algebra3.h"
 #include "tinyformat.h"
 

--- a/src/glui_treepanel.cpp
+++ b/src/glui_treepanel.cpp
@@ -16,7 +16,8 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-#include "GL/glui.h"
+#include "glui_internal_control.h"
+
 #include "tinyformat.h"
 
 

--- a/src/glui_window.cpp
+++ b/src/glui_window.cpp
@@ -26,8 +26,7 @@
 
 */
 
-#include "GL/glui.h"
-#include "glui_internal.h"
+#include "glui_internal_control.h"
 
 GLUI_Glut_Window::GLUI_Glut_Window()
 :   GLUI_Node(),

--- a/src/viewmodel.cpp
+++ b/src/viewmodel.cpp
@@ -33,9 +33,9 @@
 
 ************************************************************************/
 
-#include "viewmodel.h"
+#include "glui_internal_control.h"
 
-#include "GL/glui.h"
+#include "viewmodel.h"
 
 #include <cstdio>
 #include <cstdlib>


### PR DESCRIPTION
The Mac build produces a lot of deprecation warnings (macOS Mojave 10.14.5).

#define GL_SILENCE_DEPRECATION to make them go away.
