### PR TITLE
Initial appveyor.yml config for Windows cmake build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,38 @@
+version: '{build}'
+
+image: Visual Studio 2019
+
+environment:
+  matrix:
+    - COMPILER: "Visual Studio 16 2019"
+      ARCH: "Win32"
+      GLUT_LIBRARY: "../../glut/lib/glut32.lib"
+    - COMPILER: "Visual Studio 16 2019"
+      ARCH: "x64"
+      GLUT_LIBRARY: "../../glut/lib.x64/glut32.lib"
+
+configuration:
+  - Debug
+  - Release
+
+build_script:
+  # GLUT headers and libraries for Windows
+  - cd ..
+  - mkdir glut
+  - cd glut
+  - curl http://www.nigels.com/download/NvidiaCgGLUT_Windows.zip --output glut.zip
+  - unzip glut.zip
+  - cd ../glui
+ 
+  # Build GLUI
+  - mkdir build
+  - cd build
+  - cmake
+      -G "%COMPILER%"
+      -A "%ARCH%"
+      -DGLUT_INCLUDE_DIR=../../glut/include
+      -DGLUT_glut_LIBRARY_DEBUG="%GLUT_LIBRARY%"
+      -DGLUT_glut_LIBRARY_RELEASE="%GLUT_LIBRARY%"
+      ..
+  - cmake --build . --config %CONFIGURATION%
+  - cd ..


### PR DESCRIPTION
This provides per-push build coverage by [AppVeyor](https://www.appveyor.com/) using Visual Studio 2019 - 32-bit/64-bit and Debug and Release modes.

https://ci.appveyor.com/project/nigels-com/glui/history

This is in addition to the [Travis](https://travis-ci.org/libglui/glui/builds) Linux and Mac build coverage.